### PR TITLE
Fix building `sample_embedded_sync` target

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -42,15 +42,15 @@ target_link_libraries(sample_vmvx_sync
   ${CONDITIONAL_DEP}
 )
 
-target_sources(sample_embedded_sync
-  PRIVATE
-    simple_embedding.c
-    ${IREE_SOURCE_DIR}/iree/samples/simple_embedding/device_embedded_sync.c
-)
-
 #-------------------------------------------------------------------------------
 # DYLIB sample
 #-------------------------------------------------------------------------------
+
+target_sources(sample_embedded_sync
+  PRIVATE
+    simple_embedding.c
+    device_embedded_sync.c
+)
 
 set(_TRANSLATE_TOOL_EXECUTABLE ${IREE_HOST_BINARY_ROOT}/bin/iree-translate)
 
@@ -92,6 +92,11 @@ target_sources(simple_embedding_test_bytecode_module_dylib
   PRIVATE
     simple_embedding_test_module_dylib_arm_32.c
     simple_embedding_test_module_dylib_arm_32.h
+)
+
+target_include_directories(sample_embedded_sync
+  PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(sample_embedded_sync

--- a/samples/device_embedded_sync.c
+++ b/samples/device_embedded_sync.c
@@ -1,0 +1,71 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// A example of setting up the embedded-sync driver.
+
+#include <stddef.h>
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/hal/local/executable_loader.h"
+#include "iree/hal/local/loaders/embedded_library_loader.h"
+#include "iree/hal/local/sync_device.h"
+
+// Compiled module embedded here to avoid file IO:
+#if IREE_ARCH_ARM_32
+#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_arm_32_c.h"
+#elif IREE_ARCH_ARM_64
+#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_arm_64_c.h"
+#elif IREE_ARCH_RISCV_32
+#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_riscv_32_c.h"
+#elif IREE_ARCH_RISCV_64
+#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_riscv_64_c.h"
+#elif IREE_ARCH_X86_64
+#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_x86_64_c.h"
+#endif
+
+iree_status_t create_sample_device(iree_hal_device_t** device) {
+  // Set parameters for the device created in the next step.
+  iree_hal_sync_device_params_t params;
+  iree_hal_sync_device_params_initialize(&params);
+
+  iree_hal_executable_loader_t* loader = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_embedded_library_loader_create(
+      iree_hal_executable_import_provider_null(), iree_allocator_system(),
+      &loader));
+
+  iree_string_view_t identifier = iree_make_cstring_view("dylib");
+
+  // Create the synchronous device and release the loader afterwards.
+  iree_status_t status =
+      iree_hal_sync_device_create(identifier, &params, /*loader_count=*/1,
+                                  &loader, iree_allocator_system(), device);
+  iree_hal_executable_loader_release(loader);
+  return status;
+}
+
+const iree_const_byte_span_t load_bytecode_module_data() {
+#if IREE_ARCH_X86_64
+  const struct iree_file_toc_t* module_file_toc =
+      iree_samples_simple_embedding_test_module_dylib_x86_64_create();
+#elif IREE_ARCH_RISCV_32
+  const struct iree_file_toc_t* module_file_toc =
+      iree_samples_simple_embedding_test_module_dylib_riscv_32_create();
+#elif IREE_ARCH_RISCV_64
+  const struct iree_file_toc_t* module_file_toc =
+      iree_samples_simple_embedding_test_module_dylib_riscv_64_create();
+#elif IREE_ARCH_ARM_32
+  const struct iree_file_toc_t* module_file_toc =
+      iree_samples_simple_embedding_test_module_dylib_arm_32_create();
+#elif IREE_ARCH_ARM_64
+  const struct iree_file_toc_t* module_file_toc =
+      iree_samples_simple_embedding_test_module_dylib_arm_64_create();
+#else
+#error "Unsupported platform."
+#endif
+  return iree_make_const_byte_span(module_file_toc->data,
+                                   module_file_toc->size);
+}

--- a/samples/device_embedded_sync.c
+++ b/samples/device_embedded_sync.c
@@ -15,17 +15,7 @@
 #include "iree/hal/local/sync_device.h"
 
 // Compiled module embedded here to avoid file IO:
-#if IREE_ARCH_ARM_32
-#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_arm_32_c.h"
-#elif IREE_ARCH_ARM_64
-#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_arm_64_c.h"
-#elif IREE_ARCH_RISCV_32
-#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_riscv_32_c.h"
-#elif IREE_ARCH_RISCV_64
-#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_riscv_64_c.h"
-#elif IREE_ARCH_X86_64
-#include "iree/samples/simple_embedding/simple_embedding_test_bytecode_module_dylib_x86_64_c.h"
-#endif
+#include "simple_embedding_test_module_dylib_arm_32.h"
 
 iree_status_t create_sample_device(iree_hal_device_t** device) {
   // Set parameters for the device created in the next step.
@@ -48,24 +38,8 @@ iree_status_t create_sample_device(iree_hal_device_t** device) {
 }
 
 const iree_const_byte_span_t load_bytecode_module_data() {
-#if IREE_ARCH_X86_64
-  const struct iree_file_toc_t* module_file_toc =
-      iree_samples_simple_embedding_test_module_dylib_x86_64_create();
-#elif IREE_ARCH_RISCV_32
-  const struct iree_file_toc_t* module_file_toc =
-      iree_samples_simple_embedding_test_module_dylib_riscv_32_create();
-#elif IREE_ARCH_RISCV_64
-  const struct iree_file_toc_t* module_file_toc =
-      iree_samples_simple_embedding_test_module_dylib_riscv_64_create();
-#elif IREE_ARCH_ARM_32
   const struct iree_file_toc_t* module_file_toc =
       iree_samples_simple_embedding_test_module_dylib_arm_32_create();
-#elif IREE_ARCH_ARM_64
-  const struct iree_file_toc_t* module_file_toc =
-      iree_samples_simple_embedding_test_module_dylib_arm_64_create();
-#else
-#error "Unsupported platform."
-#endif
   return iree_make_const_byte_span(module_file_toc->data,
                                    module_file_toc->size);
 }


### PR DESCRIPTION
* Imports `device_embedded_sync.c` at state google/iree@bbb9eab.
* Adjusts `device_embedded_sync.c` to use a different dynlib.
* Adjusts the build config for `sample_embedded_sync` accordingly.