### PR TITLE
Add CI job for Renode tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,10 @@ on:
 env:
   TOOLCHAIN: gcc-arm-none-eabi
   TOOLCHAIN_VERSION: 10.3-2021.10
-  VENV: venv-iree
+  RENODE: renode
+  RENODE_VERSION: 1.12.0
+  VENV_IREE: venv-iree
+  VENV_RENODE: venv-renode
   IREE_HOST_INSTALL: build-iree-host-install
 
 jobs:
@@ -26,7 +29,7 @@ jobs:
       with:
         path: ${{ env.TOOLCHAIN }}
         key: ${{ runner.os }}-${{ env.TOOLCHAIN }}-${{ env.TOOLCHAIN_VERSION }}
-      
+
     - name: Install GNU Arm Embedded Toolchain
       if: steps.cache-toolchain.outputs.cache-hit != 'true'
       run: |
@@ -34,6 +37,29 @@ jobs:
         tar xfj gcc-arm-none-eabi-${{ env.TOOLCHAIN_VERSION }}-x86_64-linux.tar.bz2
         mv gcc-arm-none-eabi-${{ env.TOOLCHAIN_VERSION }} ${{ env.TOOLCHAIN }}
 
+  install-renode:
+    name: Install Renode
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Cache Renode
+      id: cache-renode
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ env.VENV_RENODE }}
+          ${{ env.RENODE }}
+        key: ${{ runner.os }}-${{ env.RENODE }}-${{ env.RENODE_VERSION }}
+
+    - name: Install Renode
+      if: steps.cache-renode.outputs.cache-hit != 'true'
+      run: |
+        wget -q https://github.com/renode/renode/releases/download/v${{ env.RENODE_VERSION }}/renode-${{ env.RENODE_VERSION }}.linux-portable.tar.gz
+        tar xf renode-${{ env.RENODE_VERSION }}.linux-portable.tar.gz
+        mv renode_${{ env.RENODE_VERSION }}_portable ${{ env.RENODE }}
+        python3 -m venv ${{ env.VENV_RENODE }}
+        source ${{ env.VENV_RENODE }}/bin/activate
+        pip install -r ${{ env.RENODE }}/tests/requirements.txt
 
   install-snapshot:
     name: Install IREE snaphot
@@ -50,15 +76,15 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          ${{ env.VENV }}
+          ${{ env.VENV_IREE }}
           ${{ env.IREE_HOST_INSTALL }}
         key: ${{ runner.os }}-iree-snapshot-${{ hashFiles('requirements.txt') }}
 
     - name: Install IREE Snapshot
       if: steps.cache-snapshot.outputs.cache-hit != 'true'
       run: |
-        python3 -m venv ${{ env.VENV }}
-        source ${{ env.VENV }}/bin/activate
+        python3 -m venv ${{ env.VENV_IREE }}
+        source ${{ env.VENV_IREE }}/bin/activate
         pip install -r requirements.txt
 
     - name: Install Dependencies
@@ -124,13 +150,13 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          ${{ env.VENV }}
+          ${{ env.VENV_IREE }}
           ${{ env.IREE_HOST_INSTALL }}
-        key: ${{ runner.os}}-iree-snapshot-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-iree-snapshot-${{ hashFiles('requirements.txt') }}
 
-    - name: Build with CMSIS
+    - name: Build with CMSIS for STM32F4xx
       run: |
-        source ${{ env.VENV }}/bin/activate
+        source ${{ env.VENV_IREE }}/bin/activate
         mkdir build-cmsis
         cd build-cmsis
         export PATH_TO_ARM_TOOLCHAIN="$GITHUB_WORKSPACE/${TOOLCHAIN}"
@@ -140,3 +166,49 @@ jobs:
           sample_embedded_sync \
           sample_static_library \
           sample_static_library_c
+
+    - name: Upload CMSIS build artifact for STM32F4xx
+      uses: actions/upload-artifact@master
+      with:
+        name: cmsis-stm32f4xx-build-artifact
+        path: |
+          build-cmsis/samples/sample_vmvx_sync
+          build-cmsis/samples/sample_embedded_sync
+          build-cmsis/samples/sample_static_library
+          build-cmsis/samples/sample_static_library_c
+
+  test:
+    name: Test Samples
+    needs: [install-renode, build]
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        path: ${{ env.REPO }}
+
+    - name: Cache Renode
+      id: cache-renode
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ env.VENV_RENODE }}
+          ${{ env.RENODE }}
+        key: ${{ runner.os }}-${{ env.RENODE }}-${{ env.RENODE_VERSION }}
+
+    - name: Download CMSIS build artifact for STM32F4xx
+      uses: actions/download-artifact@master
+      with:
+        name: cmsis-stm32f4xx-build-artifact
+        path: build-cmsis/samples
+
+    - name: Run Renode tests
+      run: |
+        source ${{ env.VENV_RENODE }}/bin/activate
+        ${{ env.RENODE }}/test.sh --variable BASE_DIR:$GITHUB_WORKSPACE tests/*.robot
+
+    - name: Delete CMSIS build artifact for STM32F4xx
+      uses: geekyeggo/delete-artifact@v1
+      with:
+        name: cmsis-stm32f4xx-build-artifact

--- a/tests/sample_embedded_sync.robot
+++ b/tests/sample_embedded_sync.robot
@@ -5,10 +5,10 @@ Test Setup                    Reset Emulation
 Resource                      ${RENODEKEYWORDS}
 
 *** Test Cases ***
-Should Run simple_embedding
-    Execute Command         mach create
-    Execute Command         machine LoadPlatformDescription @platforms/boards/stm32f4_discovery-kit.repl
-    Execute Command         sysbus LoadELF @${ELF}
+Should Run sample_embedded_sync
+    Execute Command         mach create "STM32F4XX"
+    Execute Command         machine LoadPlatformDescription @${BASE_DIR}/third_party/renode/stm32f4xx-highmem.repl
+    Execute Command         sysbus LoadELF @${BASE_DIR}/build-cmsis/samples/sample_embedded_sync
 
     Create Terminal Tester  sysbus.uart2
 


### PR DESCRIPTION
Adds a GitHub Action that installs Renode and runs all tests inside `tests` folder and fixes the `sample_embedded_sync` test.

The third party [`renode-test-action`](https://github.com/antmicro/renode-test-action) is not used, because we provide a `BASE_DIR` variable, so that Renode can find the scripts and build artifacts.

The built targets are shared between the build and test jobs via GitHub Artifacts. Because GitHub does not provide an builtin action to delete an artifact, a third party [`delete-artifact`](https://github.com/GeekyEggo/delete-artifact) action is used.

The Renode Scripts [`stm32f407.resc`](https://github.com/iml130/iree-bare-metal-arm/blob/main/third_party/renode/stm32f407.resc) and [`stm32f4xx-highmem.resc`](https://github.com/iml130/iree-bare-metal-arm/blob/main/third_party/renode/stm32f4xx-highmem.resc) can not be included in the robot files as is, because of the `showAnalyzer sysbus.uart2` command. Instead we do a `machine LoadPlatformDescription`.

More tests can be added in a follow up.