### PR TITLE
Only initialize a part of the submodules

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -96,9 +96,12 @@ jobs:
     - name: Install IREE Tools
       if: steps.cache-snapshot.outputs.cache-hit != 'true'
       run: |
-        git submodule update --init
+        git submodule update --init -- third_party/iree
         cd third_party/iree
-        git submodule update --init
+        git submodule update --init -- third_party/googletest
+        git submodule update --init -- third_party/flatcc
+        git submodule update --init -- third_party/libyaml
+        git submodule update --init -- third_party/vulkan_headers
         cd ../../
         mkdir ${{ env.IREE_HOST_INSTALL }}-build
         mkdir -p ${{ env.IREE_HOST_INSTALL }}/bin
@@ -106,6 +109,9 @@ jobs:
         cmake -GNinja \
               -DCMAKE_C_COMPILER=clang \
               -DCMAKE_CXX_COMPILER=clang++ \
+              -DIREE_ERROR_ON_MISSING_SUBMODULES=OFF \
+              -DIREE_ENABLE_THREADING=OFF \
+              -DIREE_HAL_DRIVERS_TO_BUILD="" \
               -DIREE_BUILD_COMPILER=OFF \
               -DIREE_BUILD_SAMPLES=OFF \
               -DIREE_BUILD_TESTS=OFF \
@@ -132,14 +138,15 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ${{ env.REPO }}
-        #submodules: 'true'
+        submodules: 'true'
 
-    # TODO(marbre): Relax `check_submodule_init` upstream.
     - name: Initalize submodules
       run : |
-        git submodule update --init
         cd third_party/iree
-        git submodule update --init
+        git submodule update --init -- third_party/googletest
+        git submodule update --init -- third_party/flatcc
+        git submodule update --init -- third_party/libyaml
+        git submodule update --init -- third_party/vulkan_headers
 
     - name: Cache Toolchain
       id: cache-toolchain

--- a/build_tools/configure_stm32f4.sh
+++ b/build_tools/configure_stm32f4.sh
@@ -90,6 +90,7 @@ cmake -GNinja \
       -DCMAKE_TOOLCHAIN_FILE="`realpath ../build_tools/cmake/arm.toolchain.cmake`" \
       -DARM_TOOLCHAIN_ROOT="${PATH_TO_ARM_TOOLCHAIN}" \
       -DARM_CPU="armv7e-m" \
+      -DIREE_ERROR_ON_MISSING_SUBMODULES=OFF \
       -DIREE_HAL_DRIVERS_TO_BUILD="VMVX_Sync;DYLIB_Sync" \
       -DIREE_HOST_BINARY_ROOT="${PATH_TO_IREE_HOST_BINARY_ROOT}" \
       -DCUSTOM_ARM_LINKER_FLAGS="${CUSTOM_ARM_LINKER_FLAGS}" \


### PR DESCRIPTION
With the `IREE_ERROR_ON_MISSING_SUBMODULES` option added to IREE (commit
google/iree@776d7e6), it is now possible to initialize a fraction of the
submodules. In particular, LLVM and TensorFlow can be skipped. Thereby,
the `Build Samples` stage runs in about 1 min instead of about 8 min.
