### PR TITLE
Add testcase for libopencm3 and tests for sample_static_library

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -259,7 +259,7 @@ jobs:
         name: cmsis-stm32f4xx-build-artifact
         path: build-cmsis/samples
 
-    - name: Download Libopencm3 build artifact for STM32F4xx
+    - name: Download libopencm3 build artifact for STM32F4xx
       uses: actions/download-artifact@master
       with:
         name: libopencm3-stm32f4xx-build-artifact

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -259,6 +259,12 @@ jobs:
         name: cmsis-stm32f4xx-build-artifact
         path: build-cmsis/samples
 
+    - name: Download Libopencm3 build artifact for STM32F4xx
+      uses: actions/download-artifact@master
+      with:
+        name: libopencm3-stm32f4xx-build-artifact
+        path: build-libopencm3/samples
+
     - name: Run Renode tests
       run: |
         source ${{ env.VENV_RENODE }}/bin/activate

--- a/tests/sample_embedded_sync.robot
+++ b/tests/sample_embedded_sync.robot
@@ -11,15 +11,15 @@ ${EXECUTABLE}       sample_embedded_sync
 
 *** Test Cases ***
 CMSIS
-    Run Sample for Library      cmsis           ${EXECUTABLE}
-    Output should show success
+    Run Sample For Library      cmsis           ${EXECUTABLE}
+    Output Should Show Success
 
 LIBOPENCM3
-    Run Sample for Library      libopencm3      ${EXECUTABLE}
-    Output should show success
+    Run Sample For Library      libopencm3      ${EXECUTABLE}
+    Output Should Show Success
 
 *** Keywords ***
-Output should show success
+Output Should Show Success
     Wait For Line On Uart       Running ${NAME}...
     Wait For Line On Uart       Execution succesfull!
     Wait For Line On Uart       ${NAME} done

--- a/tests/sample_embedded_sync.robot
+++ b/tests/sample_embedded_sync.robot
@@ -1,19 +1,22 @@
 *** Settings ***
-Suite Setup                   Setup
-Suite Teardown                Teardown
-Test Setup                    Reset Emulation
-Resource                      ${RENODEKEYWORDS}
+Suite Setup         Setup
+Suite Teardown      Teardown
+Test Setup          Reset Emulation
+Resource            ${RENODEKEYWORDS}
+Resource            samples.resource
+
+*** Variables ***
+${NAME}             simple_embedding
+${EXECUTABLE}       sample_embedded_sync
 
 *** Test Cases ***
-Should Run sample_embedded_sync
-    Execute Command         mach create "STM32F4XX"
-    Execute Command         machine LoadPlatformDescription @${BASE_DIR}/third_party/renode/stm32f4xx-highmem.repl
-    Execute Command         sysbus LoadELF @${BASE_DIR}/build-cmsis/samples/sample_embedded_sync
+CMSIS
+    Run Sample for Library      cmsis           ${EXECUTABLE}
+    Output should show success
 
-    Create Terminal Tester  sysbus.uart2
 
-    Start Emulation
-
-    Wait For Line On Uart   Running simple_embedding...
-    Wait For Line On Uart   Execution succesfull!
-    Wait For Line On Uart   simple_embedding done
+*** Keywords ***
+Output should show success
+    Wait For Line On Uart       Running ${NAME}...
+    Wait For Line On Uart       Execution succesfull!
+    Wait For Line On Uart       ${NAME} done

--- a/tests/sample_embedded_sync.robot
+++ b/tests/sample_embedded_sync.robot
@@ -14,6 +14,9 @@ CMSIS
     Run Sample for Library      cmsis           ${EXECUTABLE}
     Output should show success
 
+LIBOPENCM3
+    Run Sample for Library      libopencm3      ${EXECUTABLE}
+    Output should show success
 
 *** Keywords ***
 Output should show success

--- a/tests/sample_static_library.robot
+++ b/tests/sample_static_library.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+Suite Setup         Setup
+Suite Teardown      Teardown
+Test Setup          Reset Emulation
+Resource            ${RENODEKEYWORDS}
+Resource            samples.resource
+
+*** Variables ***
+${EXECUTABLE}       sample_static_library
+
+*** Test Cases ***
+CMSIS
+    Run Sample for Library      cmsis           ${EXECUTABLE}
+    Output should show success
+
+LIBOPENCM3
+    Run Sample for Library      libopencm3      ${EXECUTABLE}
+    Output should show success
+
+*** Keywords ***
+Output should show success
+    Wait For Line On Uart       Execution succesfull!
+    Wait For Line On Uart       static_library_run_bytecode passed

--- a/tests/sample_static_library.robot
+++ b/tests/sample_static_library.robot
@@ -10,14 +10,14 @@ ${EXECUTABLE}       sample_static_library
 
 *** Test Cases ***
 CMSIS
-    Run Sample for Library      cmsis           ${EXECUTABLE}
-    Output should show success
+    Run Sample For Library      cmsis           ${EXECUTABLE}
+    Output Should Show Success
 
 LIBOPENCM3
-    Run Sample for Library      libopencm3      ${EXECUTABLE}
-    Output should show success
+    Run Sample For Library      libopencm3      ${EXECUTABLE}
+    Output Should Show Success
 
 *** Keywords ***
-Output should show success
+Output Should Show Success
     Wait For Line On Uart       Execution succesfull!
     Wait For Line On Uart       static_library_run_bytecode passed

--- a/tests/samples.resource
+++ b/tests/samples.resource
@@ -1,0 +1,27 @@
+*** Settings ***
+Documentation       Defining resources for testing the generated samples
+
+*** Variables ***
+${MACHINE}          STM32F4XX
+${PLATFORMFILE}     @${BASE_DIR}/third_party/renode/stm32f4xx-highmem.repl
+
+*** Keywords ***
+Run Sample for Library
+    [Arguments]             ${lib}  ${executable}
+
+    Setup Machine
+    Load Sample             ${executable}   ${lib}
+    Run Emulation
+
+Setup Machine
+    Execute Command         mach create "${MACHINE}"
+    Execute Command         machine LoadPlatformDescription ${PLATFORMFILE}
+
+Load Sample
+    [Arguments]             ${executable}   ${lib}
+
+    Execute Command         sysbus LoadELF @${BASE_DIR}/build-${lib}/samples/${executable}
+
+Run Emulation
+    Create Terminal Tester  sysbus.uart2
+    Start Emulation

--- a/tests/samples.resource
+++ b/tests/samples.resource
@@ -6,7 +6,7 @@ ${MACHINE}          STM32F4XX
 ${PLATFORMFILE}     @${BASE_DIR}/third_party/renode/stm32f4xx-highmem.repl
 
 *** Keywords ***
-Run Sample for Library
+Run Sample For Library
     [Arguments]             ${lib}  ${executable}
 
     Setup Machine


### PR DESCRIPTION
Refactor the existing embedded_sync test to use generic keywords based on variables for reusability.
Add a libopencm3 testcase for the embedded_sync sample.
Add testcases for the static_library sample.
Download libopencm3 artifacts in github actions test job.