### PR TITLE
Introduce `ARM_TARGET` property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,28 @@ if(NOT BUILD_WITH_CMSIS AND NOT BUILD_WITH_CRT0 AND NOT BUILD_WITH_LIBOPENCM3)
   message(FATAL_ERROR "Either set BUILD_WITH_CMSIS, BUILD_WITH_CRT0 or BUILD_WITH_LIBOPENCM3 to ON")
 endif()
 
+set(ARM_TARGET STM32F407 CACHE STRING "Target for which the samples are build")
+set(ARM_TARGET_VALUES "STM32F407;STM32F4XX" CACHE INTERNAL "List of possible targets")
+set_property(CACHE ARM_TARGET PROPERTY STRINGS ${ARM_TARGET_VALUES})
+string(TOUPPER "${ARM_TARGET}" ARM_TARGET)
+
+# Check if the target is supported
+if(NOT ARM_TARGET IN_LIST ARM_TARGET_VALUES)
+  message(FATAL_ERROR "${ARM_TARGET} is not supported!")
+else()
+  message(STATUS "Building samples for ${ARM_TARGET}")
+endif()
+
+# Check if the combination of library and target is supported
+if(NOT (ARM_TARGET STREQUAL "STM32F407" OR ARM_TARGET STREQUAL "STM32F4XX") AND
+   (BUILD_WITH_CRT0 OR BUILD_WITH_LIBOPENCM3))
+  message(FATAL_ERROR "Devices other than STM32F407 or STM32F4XX are only supported with CMSIS")
+endif()
+
+#-------------------------------------------------------------------------------
+# Third-party dependencies
+#-------------------------------------------------------------------------------
+
 # Extend module path to allow submodules to find AddMLIR
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_BINARY_DIR}/lib/cmake/mlir")
 
@@ -44,10 +66,6 @@ add_definitions(-DIREE_PLATFORM_GENERIC)
 add_definitions(-DIREE_SYNCHRONIZATION_DISABLE_UNSAFE=1)
 add_definitions(-DIREE_STATUS_FEATURES=0)
 add_definitions(-DFLATCC_USE_GENERIC_ALIGNED_ALLOC)
-
-#-------------------------------------------------------------------------------
-# Third-party dependencies
-#-------------------------------------------------------------------------------
 
 add_subdirectory(build_tools/third_party/cmsis_device_f4 EXCLUDE_FROM_ALL)
 add_subdirectory(build_tools/third_party/custom_crt0 EXCLUDE_FROM_ALL)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ cmake -GNinja \
       -DCMAKE_TOOLCHAIN_FILE="`realpath ../build_tools/cmake/arm.toolchain.cmake`" \
       -DARM_TOOLCHAIN_ROOT="${PATH_TO_ARM_TOOLCHAIN}" \
       -DARM_CPU="cortex-m4" \
+      -DARM_TARGET="STM32F407" \
       -DIREE_HAL_DRIVER_DEFAULTS=OFF \
       -DIREE_HAL_DRIVER_DYLIB_SYNC=ON \
       -DIREE_HAL_DRIVER_VMVX_SYNC=ON \

--- a/build_tools/configure_stm32f4.sh
+++ b/build_tools/configure_stm32f4.sh
@@ -90,6 +90,7 @@ cmake -GNinja \
       -DCMAKE_TOOLCHAIN_FILE="`realpath ../build_tools/cmake/arm.toolchain.cmake`" \
       -DARM_TOOLCHAIN_ROOT="${PATH_TO_ARM_TOOLCHAIN}" \
       -DARM_CPU="cortex-m4" \
+      -DARM_TARGET="${2^^}" \
       -DIREE_ERROR_ON_MISSING_SUBMODULES=OFF \
       -DIREE_HAL_DRIVER_DEFAULTS=OFF \
       -DIREE_HAL_DRIVER_DYLIB_SYNC=ON \

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -4,7 +4,11 @@
 
 if(BUILD_WITH_CMSIS)
   set(UTILS_SRC ${CMAKE_SOURCE_DIR}/utils/stm32f4_cmsis.c)
-  set(CONDITIONAL_DEP cmsis_device_f407)
+  if(ARM_TARGET STREQUAL "STM32F407" OR ARM_TARGET STREQUAL "STM32F4XX")
+    set(CONDITIONAL_DEP cmsis_device_f407)
+  elseif(ARM_TARGET STREQUAL "STM32F446")
+    set(CONDITIONAL_DEP cmsis_device_f446)
+  endif()
 endif()
 
 if(BUILD_WITH_CRT0)


### PR DESCRIPTION
Introduces a property named `ARM_TARGET` to specify the target board for
which the samples should be build. The property defaults to `STM32F407`.
Building samples for targets other than `STM32F407` or `STM32F4XX` is
restricted to CMSIS.
Amongst other things, corresponding strings have to be added to the
`ARM_TARGET_VALUES` list to expand support for new targets.