### PR TITLE
Remove CUSTOM_ARM_LINKER_FLAGS for CMSIS and CRT0

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cd build
 # export PATH_TO_ARM_TOOLCHAIN="/usr/local/gcc-arm-none-eabi-10.3-2021.10"
 
 # To build with CMSIS
-# export CUSTOM_ARM_LINKER_FLAGS="-lnosys"
+# export CUSTOM_ARM_LINKER_FLAGS=""
 # export PATH_TO_LINKER_SCRIPT="`realpath ../build_tools/stm32f407xg-cmsis.ld`"
 
 # To build with libopencm3

--- a/build_tools/configure_stm32f4.sh
+++ b/build_tools/configure_stm32f4.sh
@@ -17,13 +17,13 @@ fi
 case $1 in
   cmsis)
     echo "Building with CMSIS"
-    export CUSTOM_ARM_LINKER_FLAGS="-lnosys"
+    export CUSTOM_ARM_LINKER_FLAGS=""
     export BUILD_WITH="CMSIS"
     ;;
   
   crt0)
     echo "Building with crt0.s"
-    export CUSTOM_ARM_LINKER_FLAGS="-lnosys"
+    export CUSTOM_ARM_LINKER_FLAGS=""
     export BUILD_WITH="CRT0"
     ;;
 


### PR DESCRIPTION
 Removes the custom linker flag `-lnosys` for libs CMSIS and CRT0 as `nosys.specs` is provided in [`arm.toolchain.cmake`](https://github.com/iml130/iree-bare-metal-arm/blob/fd03a07dc60b6aac4babd257c7f642c06771645a/build_tools/cmake/arm.toolchain.cmake#L24).