### PR TITLE
Generate ihex files by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 option(BUILD_WITH_CMSIS "Builds the sample with CMSIS" OFF)
 option(BUILD_WITH_CRT0 "Builds the sample with crt0.s" OFF)
 option(BUILD_WITH_LIBOPENCM3 "Builds the sample with libopencm3" OFF)
+option(BUILD_IHEX "Build ihex files in addition to ELF files" ON)
 
 if(
   (BUILD_WITH_CMSIS AND BUILD_WITH_CRT0) OR
@@ -53,6 +54,16 @@ endif()
 if(ARM_TARGET STREQUAL "STM32F407" AND USE_UART1)
   message(FATAL_ERROR "UART1 is not supported for STM32F407")
 endif()
+
+#-------------------------------------------------------------------------------
+# Utility definitions
+#-------------------------------------------------------------------------------
+
+list(APPEND CMAKE_MODULE_PATH
+  ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake/
+)
+
+include(add_ihex)
 
 #-------------------------------------------------------------------------------
 # Third-party dependencies

--- a/build_tools/cmake/add_ihex.cmake
+++ b/build_tools/cmake/add_ihex.cmake
@@ -1,0 +1,20 @@
+# Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# add_bare_metal_executable()
+#
+# CMake function to add a hex file.
+
+function(add_ihex TARGET)
+  if(NOT BUILD_IHEX)
+    return()
+  endif()
+
+  add_custom_command(
+    TARGET ${TARGET} POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -O ihex ${TARGET} ${TARGET}.hex
+  )
+endfunction()

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -73,6 +73,8 @@ if(IREE_HAL_DRIVER_VMVX_SYNC)
     ${CONDITIONAL_DEP}
   )
 
+  add_ihex(sample_vmvx_sync)
+
 endif()
 
 #-------------------------------------------------------------------------------
@@ -145,3 +147,5 @@ target_link_libraries(sample_embedded_sync
   iree::vm::bytecode_module
   ${CONDITIONAL_DEP}
 )
+
+add_ihex(sample_embedded_sync)

--- a/samples/static_library/CMakeLists.txt
+++ b/samples/static_library/CMakeLists.txt
@@ -82,6 +82,8 @@ target_link_libraries(sample_static_library
   ${CONDITIONAL_DEP}
 )
 
+add_ihex(sample_static_library)
+
 #-------------------------------------------------------------------------------
 # Static library sample, EmitC
 #-------------------------------------------------------------------------------
@@ -148,3 +150,5 @@ target_link_libraries(sample_static_library_c
   iree::vm::shims_emitc
   ${CONDITIONAL_DEP}
 )
+
+add_ihex(sample_static_library_c)


### PR DESCRIPTION
Adds a CMake function that utilizes objcopy to generate ihex files
alongside with the ELF files.