### PR TITLE
Update toolchain to 11.2-2022.02

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   TOOLCHAIN: gcc-arm-none-eabi
-  TOOLCHAIN_VERSION: 10.3-2021.10
+  TOOLCHAIN_VERSION: 11.2-2022.02
   RENODE: renode
   RENODE_VERSION: 1.12.0
   VENV_IREE: venv-iree
@@ -19,7 +19,7 @@ env:
 
 jobs:
   install-toolchain:
-    name: Install GNU Arm Embedded Toolchain
+    name: Install Arm GNU Toolchain
     runs-on: ubuntu-20.04
 
     steps:
@@ -28,14 +28,14 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.TOOLCHAIN }}
-        key: ${{ runner.os }}-${{ env.TOOLCHAIN }}-${{ env.TOOLCHAIN_VERSION }}
+        key: ${{ runner.os }}-gcc-arm-${{ env.TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi
 
     - name: Install GNU Arm Embedded Toolchain
       if: steps.cache-toolchain.outputs.cache-hit != 'true'
       run: |
-        wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/${{ env.TOOLCHAIN_VERSION }}/gcc-arm-none-eabi-${{ env.TOOLCHAIN_VERSION }}-x86_64-linux.tar.bz2
-        tar xfj gcc-arm-none-eabi-${{ env.TOOLCHAIN_VERSION }}-x86_64-linux.tar.bz2
-        mv gcc-arm-none-eabi-${{ env.TOOLCHAIN_VERSION }} ${{ env.TOOLCHAIN }}
+        wget -q https://developer.arm.com/-/media/Files/downloads/gnu/${{ env.TOOLCHAIN_VERSION }}/binrel/gcc-arm-${{ env.TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi.tar.xz
+        tar xfJ gcc-arm-${{ env.TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi.tar.xz
+        mv gcc-arm-${{ env.TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi ${{ env.TOOLCHAIN }}
 
   install-renode:
     name: Install Renode
@@ -153,7 +153,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.TOOLCHAIN }}
-        key: ${{ runner.os }}-${{ env.TOOLCHAIN }}-${{ env.TOOLCHAIN_VERSION }}
+        key: ${{ runner.os }}-gcc-arm-${{ env.TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi
 
     - name: Cache IREE Snapshot
       id: cache-snapshot

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 This project is not intended for everyday use and made available without any support.
 However, we welcome any kind of feedback via the issue tracker or if appropriate via IREE's [communication channels](https://github.com/google/iree#communication-channels), e.g. via the Discord server.
 
-This projects demonstrates how to build [IREE](https://github.com/google/iree) with the [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm) for bare-metal Arm targets using either the open-source firmware library [libopencm3](https://github.com/libopencm3/libopencm3) or [CMSIS](https://github.com/ARM-software/CMSIS_5).
+This projects demonstrates how to build [IREE](https://github.com/google/iree) with the [Arm GNU Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain) for bare-metal Arm targets using either the open-source firmware library [libopencm3](https://github.com/libopencm3/libopencm3) or [CMSIS](https://github.com/ARM-software/CMSIS_5).
 ## Getting Started
 
 ### Prerequisites
 
-You need CMake and the [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm) installed on your host machine. Further, a C/C++ compiler is required to build IREE for your host machine.
+You need CMake and the [Arm GNU Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain) installed on your host machine. Further, a C/C++ compiler is required to build IREE for your host machine.
 
 ### Clone and Build
 #### Clone
@@ -113,7 +113,7 @@ mkdir build
 cd build
 
 # Set the path to the GNU Arm Embedded Toolchain, e.g.
-# export PATH_TO_ARM_TOOLCHAIN="/usr/local/gcc-arm-none-eabi-10.3-2021.10"
+# export PATH_TO_ARM_TOOLCHAIN="/usr/local/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi"
 
 # To build with CMSIS
 # export CUSTOM_ARM_LINKER_FLAGS=""

--- a/build_tools/configure_build.sh
+++ b/build_tools/configure_build.sh
@@ -15,7 +15,7 @@ fi
 
 # Set the path to the GNU Arm Embedded Toolchain
 if [ -z ${PATH_TO_ARM_TOOLCHAIN+x} ]; then
-  export PATH_TO_ARM_TOOLCHAIN="/usr/local/gcc-arm-none-eabi-10.3-2021.10"
+  export PATH_TO_ARM_TOOLCHAIN="/usr/local/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi"
 fi
 
 # Set linker flags


### PR DESCRIPTION
Updates to use the Arm GNU Toolchain version 11.2-2022.02.