### PR TITLE
Refactor to use C startup code

### DIFF
--- a/build_tools/stm32-cmsis-base.ld
+++ b/build_tools/stm32-cmsis-base.ld
@@ -151,7 +151,7 @@ SECTIONS
 
     LONG (__etext)
     LONG (__data_start__)
-    LONG ((__data_end__ - __data_start__) / 4)
+    LONG ((__data_end__ - __data_start__))
 
     /* Add each additional data section here */
 /*
@@ -166,6 +166,8 @@ SECTIONS
   {
     . = ALIGN(4);
     __zero_table_start__ = .;
+    LONG (__bss_start__)
+    LONG ((__bss_end__ - __bss_start__))
     /* Add each additional bss section here */
 /*
     LONG (__bss2_start__)

--- a/build_tools/third_party/cmsis_device_f4/CMakeLists.txt
+++ b/build_tools/third_party/cmsis_device_f4/CMakeLists.txt
@@ -11,20 +11,27 @@ set(CMSIS_5_SOURCE_DIR "${PROJECT_SOURCE_DIR}/third_party/CMSIS_5/")
 
 add_library(cmsis_device_f407xx STATIC "")
 
-target_sources(cmsis_device_f407xx PRIVATE
-  ${cmsis_device_f4_SOURCE_DIR}/Source/Templates/system_stm32f4xx.c
-  ${cmsis_device_f4_SOURCE_DIR}/Source/Templates/gcc/startup_stm32f407xx.s
+target_sources(cmsis_device_f407xx
+  PRIVATE
+    ${cmsis_device_f4_SOURCE_DIR}/Source/Templates/system_stm32f4xx.c
+    ${CMSIS_5_SOURCE_DIR}/Device/ARM/ARMCM4/Source/startup_ARMCM4.c
 )
 
 target_include_directories(cmsis_device_f407xx
   PUBLIC
-  ${cmsis_device_f4_SOURCE_DIR}/Include/
-  ${CMSIS_5_SOURCE_DIR}/CMSIS/Core/Include/
+    ${cmsis_device_f4_SOURCE_DIR}/Include/
+    ${CMSIS_5_SOURCE_DIR}/CMSIS/Core/Include/
+  PRIVATE
+    ${CMSIS_5_SOURCE_DIR}/Device/ARM/ARMCM4/Include
 )
 
 target_compile_definitions(cmsis_device_f407xx
-  PUBLIC STM32F407xx
-  PRIVATE HSI_VALUE=16000000 HSE_VALUE=8000000
+  PUBLIC
+    STM32F407xx
+  PRIVATE
+    HSI_VALUE=16000000
+    HSE_VALUE=8000000
+    ARMCM4_FP
 )
 
 # Allow ld to find generic linker script
@@ -36,20 +43,27 @@ target_link_directories(cmsis_device_f407xx INTERFACE "${PROJECT_SOURCE_DIR}/bui
 
 add_library(cmsis_device_f411xe STATIC "")
 
-target_sources(cmsis_device_f411xe PRIVATE
-  ${cmsis_device_f4_SOURCE_DIR}/Source/Templates/system_stm32f4xx.c
-  ${cmsis_device_f4_SOURCE_DIR}/Source/Templates/gcc/startup_stm32f411xe.s
+target_sources(cmsis_device_f411xe
+  PRIVATE
+    ${cmsis_device_f4_SOURCE_DIR}/Source/Templates/system_stm32f4xx.c
+    ${CMSIS_5_SOURCE_DIR}/Device/ARM/ARMCM4/Source/startup_ARMCM4.c
 )
 
 target_include_directories(cmsis_device_f411xe
   PUBLIC
-  ${cmsis_device_f4_SOURCE_DIR}/Include/
-  ${CMSIS_5_SOURCE_DIR}/CMSIS/Core/Include/
+    ${cmsis_device_f4_SOURCE_DIR}/Include/
+    ${CMSIS_5_SOURCE_DIR}/CMSIS/Core/Include/
+  PRIVATE
+    ${CMSIS_5_SOURCE_DIR}/Device/ARM/ARMCM4/Include
 )
 
 target_compile_definitions(cmsis_device_f411xe
-  PUBLIC STM32F411xE
-  PRIVATE HSI_VALUE=16000000 HSE_VALUE=8000000
+  PUBLIC
+    STM32F411xE
+  PRIVATE
+    HSI_VALUE=16000000
+    HSE_VALUE=8000000
+    ARMCM4_FP
 )
 
 # Allow ld to find generic linker script
@@ -61,20 +75,27 @@ target_link_directories(cmsis_device_f411xe INTERFACE "${PROJECT_SOURCE_DIR}/bui
 
 add_library(cmsis_device_f446xx STATIC "")
 
-target_sources(cmsis_device_f446xx PRIVATE
-  ${cmsis_device_f4_SOURCE_DIR}/Source/Templates/system_stm32f4xx.c
-  ${cmsis_device_f4_SOURCE_DIR}/Source/Templates/gcc/startup_stm32f446xx.s
+target_sources(cmsis_device_f446xx
+  PRIVATE
+    ${cmsis_device_f4_SOURCE_DIR}/Source/Templates/system_stm32f4xx.c
+    ${CMSIS_5_SOURCE_DIR}/Device/ARM/ARMCM4/Source/startup_ARMCM4.c
 )
 
 target_include_directories(cmsis_device_f446xx
   PUBLIC
-  ${cmsis_device_f4_SOURCE_DIR}/Include/
-  ${CMSIS_5_SOURCE_DIR}/CMSIS/Core/Include/
+    ${cmsis_device_f4_SOURCE_DIR}/Include/
+    ${CMSIS_5_SOURCE_DIR}/CMSIS/Core/Include/
+  PRIVATE
+    ${CMSIS_5_SOURCE_DIR}/Device/ARM/ARMCM4/Include
 )
 
 target_compile_definitions(cmsis_device_f446xx
-  PUBLIC STM32F446xx
-  PRIVATE HSI_VALUE=16000000 HSE_VALUE=8000000
+  PUBLIC
+    STM32F446xx
+  PRIVATE
+    HSI_VALUE=16000000
+    HSE_VALUE=8000000
+    ARMCM4_FP
 )
 
 # Allow ld to find generic linker script

--- a/build_tools/third_party/cmsis_device_f7/CMakeLists.txt
+++ b/build_tools/third_party/cmsis_device_f7/CMakeLists.txt
@@ -11,18 +11,26 @@ set(CMSIS_5_SOURCE_DIR "${PROJECT_SOURCE_DIR}/third_party/CMSIS_5/")
 
 add_library(cmsis_device_f746xx STATIC "")
 
-target_sources(cmsis_device_f746xx PRIVATE
-  ${cmsis_device_f7_SOURCE_DIR}/Source/Templates/system_stm32f7xx.c
-  ${cmsis_device_f7_SOURCE_DIR}/Source/Templates/gcc/startup_stm32f746xx.s
+target_sources(cmsis_device_f746xx
+  PRIVATE
+    ${cmsis_device_f7_SOURCE_DIR}/Source/Templates/system_stm32f7xx.c
+    ${CMSIS_5_SOURCE_DIR}/Device/ARM/ARMCM7/Source/startup_ARMCM7.c
 )
 
 target_include_directories(cmsis_device_f746xx
   PUBLIC
-  ${cmsis_device_f7_SOURCE_DIR}/Include/
-  ${CMSIS_5_SOURCE_DIR}/CMSIS/Core/Include/
+    ${cmsis_device_f7_SOURCE_DIR}/Include/
+    ${CMSIS_5_SOURCE_DIR}/CMSIS/Core/Include/
+  PRIVATE
+    ${CMSIS_5_SOURCE_DIR}/Device/ARM/ARMCM7/Include
 )
 
-target_compile_definitions(cmsis_device_f746xx PUBLIC -DSTM32F746xx)
+target_compile_definitions(cmsis_device_f746xx
+  PUBLIC
+    STM32F746xx
+  PRIVATE
+    ARMCM7_SP
+)
 
 # Allow ld to find generic linker script
 target_link_directories(cmsis_device_f746xx INTERFACE "${PROJECT_SOURCE_DIR}/build_tools/")


### PR DESCRIPTION
This refactors the CMSIS based targets to use startup code writen in C
instead of using the one written in assembler.

Test on
* STM32F411RE
* STM32F446RE
* STM32F407VG (Renode only)
* STM32F746ZG (Renode only)

Co-authored-by: Lucas Camphausen <lucas.camphausen@iml.fraunhofer.de>
Co-authored-by: Simon Camphausen <simon.camphausen@iml.fraunhofer.de>
Co-authored-by: David Ronnenberg <david.ronnenberg@iml.fraunhofer.de>