### PR TITLE
Bump ethos-u-core-platform to commit d798c6ef

### DIFF
--- a/build_tools/platform_parsed.patch
+++ b/build_tools/platform_parsed.patch
@@ -5,12 +5,10 @@ Authored-by: Marius Brehler <marius.brehler@iml.fraunhofer.de>
 SPDX-License-Identifier: Apache-2.0
 --- a/platform_parsed.ld
 +++ b/platform_parsed.ld
-@@ -166,7 +166,18 @@
-     __copy_table_start__ = .;
+@@ -167,6 +167,17 @@ SECTIONS
      LONG (__etext)
      LONG (__data_start__)
--    LONG (__data_end__ - __data_start__)
-+    LONG ((__data_end__ - __data_start__) / 4)
+     LONG ((__data_end__ - __data_start__) / 4)
 +
 +    /* .got section */
 +    LONG (LOADADDR(.got))
@@ -24,21 +22,11 @@ SPDX-License-Identifier: Apache-2.0
 +
      LONG (__eddr_data)
      LONG (__sram_data_start__)
-     LONG (__sram_data_end__ - __sram_data_start__ )
-@@ -177,7 +188,7 @@
-     . = ALIGN(4);
-     __zero_table_start__ = .;
-     LONG (__bss_start__)
--    LONG (__bss_end__ - __bss_start__)
-+    LONG ((__bss_end__ - __bss_start__) / 4)
-     __zero_table_end__ = .;
-   /**
-    * Location counter can end up 2byte aligned with narrow Thumb code but
-@@ -214,6 +225,25 @@
+     LONG ((__sram_data_end__ - __sram_data_start__) / 4)
+@@ -214,6 +225,22 @@ SECTIONS
      /* All data end */
      __data_end__ = .;
    } > DTCM :rom_exec
-+
 +  .got :
 +  {
 +    . = ALIGN(4);
@@ -47,7 +35,6 @@ SPDX-License-Identifier: Apache-2.0
 +    . = ALIGN(4);
 +    __got_end__ = .;
 +  } > DTCM :rom_exec
-+
 +  .got.plt :
 +  {
 +    . = ALIGN(4);
@@ -56,7 +43,6 @@ SPDX-License-Identifier: Apache-2.0
 +    . = ALIGN(4);
 +    __got_plt_end__ = .;
 +  } > DTCM :rom_exec
-+
    .sram.bss :
    {
      . = ALIGN(16);


### PR DESCRIPTION
Bumps the ethos-u-core-platform submodule to commit d798c6f. The
submodule now also ships a fix regarding bytes/words sizes of the data
and bss section, see
https://git.mlplatform.org/ml/ethos-u/ethos-u-core-platform.git/commit/?id=8b53aad76ea95dc1f4c8ce64b6f8dc14f727b46f