### PR TITLE
Add helper script to init IREE's submodules

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,12 +97,7 @@ jobs:
       if: steps.cache-snapshot.outputs.cache-hit != 'true'
       run: |
         git submodule update --init -- third_party/iree
-        cd third_party/iree
-        git submodule update --init -- third_party/googletest
-        git submodule update --init -- third_party/flatcc
-        git submodule update --init -- third_party/libyaml
-        git submodule update --init -- third_party/vulkan_headers
-        cd ../../
+        ./build_tools/init_iree_submodules.sh
         mkdir ${{ env.IREE_HOST_INSTALL }}-build
         mkdir -p ${{ env.IREE_HOST_INSTALL }}/bin
         cd ${{ env.IREE_HOST_INSTALL }}-build

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ You need CMake and the [Arm GNU Toolchain](https://developer.arm.com/tools-and-s
 git clone https://github.com/iml130/iree-bare-metal-arm.git
 cd iree-bare-metal-arm
 git submodule update --init
-cd third_party/iree
-git submodule update --init
-cd ../../
+./build_tools/init_iree_submodules.sh
 ```
 > Note:<br>
 > &nbsp;&nbsp;&nbsp;&nbsp;The submodules used within IREE themself include submodules, so that we advice to avoid an recursive update.
@@ -86,6 +84,7 @@ cd build-iree-host-tools
 cmake -GNinja \
       -DCMAKE_C_COMPILER=clang \
       -DCMAKE_CXX_COMPILER=clang++ \
+      -DIREE_ERROR_ON_MISSING_SUBMODULES=OFF \
       -DIREE_HAL_DRIVER_DEFAULTS=OFF \
       -DIREE_BUILD_COMPILER=OFF \
       -DIREE_BUILD_SAMPLES=OFF \

--- a/build_tools/init_iree_submodules.sh
+++ b/build_tools/init_iree_submodules.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Bash script to initalize the strickly needed IREE submodules.
+
+ORIGINAL_PATH="`pwd`"
+PATH_TO_SCRIPT="`dirname $0`"
+PATH_TO_IREE="`realpath ${PATH_TO_SCRIPT}/../third_party/iree/`"
+
+if ! [ -f "${PATH_TO_IREE}/CMakeLists.txt" ]; then
+  echo "Expected IREE submodule to be initalized: can't find CMakeLists.txt"
+  exit 1
+fi
+
+cd ${PATH_TO_IREE}
+git submodule update --init -- third_party/googletest
+git submodule update --init -- third_party/flatcc
+git submodule update --init -- third_party/libyaml
+git submodule update --init -- third_party/vulkan_headers
+cd ${ORIGINAL_PATH}


### PR DESCRIPTION
This enables to skip `git submodule update --init` within the IREE
submodule and to hence to configure IREE with
`IREE_ERROR_ON_MISSING_SUBMODULES` set to `OFF`.