### PR TITLE
Disable unaligned memory access

### DIFF
--- a/build_tools/cmake/arm-none-eabi-gcc.cmake
+++ b/build_tools/cmake/arm-none-eabi-gcc.cmake
@@ -63,15 +63,15 @@ set(ARM_LINKER_FLAGS "-lc -lm ${CUSTOM_ARM_LINKER_FLAGS} -T ${LINKER_SCRIPT}")
 set(ARM_LINKER_FLAGS_EXE)
 
 if(ARM_CPU STREQUAL "cortex-m4")
-  list(APPEND ARM_COMPILER_FLAGS "-mthumb -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -DIREE_TIME_NOW_FN=\"\{ return 0; \}\" -DIREE_WAIT_UNTIL_FN=wait_until -Wl,--gc-sections -ffunction-sections -fdata-sections")
+  list(APPEND ARM_COMPILER_FLAGS "-mthumb -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -DIREE_TIME_NOW_FN=\"\{ return 0; \}\" -DIREE_WAIT_UNTIL_FN=wait_until -Wl,--gc-sections -ffunction-sections -fdata-sections -mno-unaligned-access")
 elseif(ARM_CPU STREQUAL "cortex-m7" OR ARM_CPU STREQUAL "cortex-m7-sp")
   # Single-precision FPU
-  list(APPEND ARM_COMPILER_FLAGS "-mthumb -march=armv7e-m -mfloat-abi=hard -mfpu=fpv5-sp-d16 -DIREE_TIME_NOW_FN=\"\{ return 0; \}\" -DIREE_WAIT_UNTIL_FN=wait_until -Wl,--gc-sections -ffunction-sections -fdata-sections")
+  list(APPEND ARM_COMPILER_FLAGS "-mthumb -march=armv7e-m -mfloat-abi=hard -mfpu=fpv5-sp-d16 -DIREE_TIME_NOW_FN=\"\{ return 0; \}\" -DIREE_WAIT_UNTIL_FN=wait_until -Wl,--gc-sections -ffunction-sections -fdata-sections -mno-unaligned-access")
 elseif(ARM_CPU STREQUAL "cortex-m7-dp")
   # Single- and double-precision FPU
-  list(APPEND ARM_COMPILER_FLAGS "-mthumb -march=armv7e-m -mfloat-abi=hard -mfpu=fpv5-d16 -DIREE_TIME_NOW_FN=\"\{ return 0; \}\" -DIREE_WAIT_UNTIL_FN=wait_until -Wl,--gc-sections -ffunction-sections -fdata-sections")
+  list(APPEND ARM_COMPILER_FLAGS "-mthumb -march=armv7e-m -mfloat-abi=hard -mfpu=fpv5-d16 -DIREE_TIME_NOW_FN=\"\{ return 0; \}\" -DIREE_WAIT_UNTIL_FN=wait_until -Wl,--gc-sections -ffunction-sections -fdata-sections -mno-unaligned-access")
 elseif(ARM_CPU STREQUAL "cortex-m55")
-  list(APPEND ARM_COMPILER_FLAGS "-mthumb -mcpu=cortex-m55 -mfloat-abi=hard -DIREE_TIME_NOW_FN=\"\{ return 0; \}\" -DIREE_WAIT_UNTIL_FN=wait_until  -Wl,--gc-sections -ffunction-sections -fdata-sections")
+  list(APPEND ARM_COMPILER_FLAGS "-mthumb -mcpu=cortex-m55 -mfloat-abi=hard -DIREE_TIME_NOW_FN=\"\{ return 0; \}\" -DIREE_WAIT_UNTIL_FN=wait_until  -Wl,--gc-sections -ffunction-sections -fdata-sections -mno-unaligned-access")
 endif()
 
 set(CMAKE_C_FLAGS             "${ARM_COMPILER_FLAGS} ${CMAKE_C_FLAGS}")


### PR DESCRIPTION
Pass `-mno-unaligned-access` to work around google/iree#9593 until we've
landed a fix.