### PR TITLE
Update required submodules

### DIFF
--- a/build_tools/update_iree_submodules.sh
+++ b/build_tools/update_iree_submodules.sh
@@ -22,7 +22,6 @@ cd ${PATH_TO_IREE}
 git submodule update --init -- third_party/googletest
 git submodule update --init -- third_party/flatcc
 git submodule update --init -- third_party/libyaml
-git submodule update --init -- third_party/vulkan_headers
 cd ${ORIGINAL_PATH}
 
 echo "Updated the required IREE submodules."


### PR DESCRIPTION
With google/iree@9b86ad5, there is no longer a need to clone the
vulkan_headers submodule.