### PR TITLE
Rework variable namings

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -22,11 +22,11 @@ endif()
 
 if(EXISTS ${IREE_HOST_BINARY_ROOT}/bin/iree-compile)
   # Use `iree-compile` if installed to IREE_HOST_BINARY_ROOT.
-  set(_TRANSLATE_TOOL_EXECUTABLE ${IREE_HOST_BINARY_ROOT}/bin/iree-compile)
+  set(_COMPILE_TOOL_EXECUTABLE ${IREE_HOST_BINARY_ROOT}/bin/iree-compile)
 else()
   # Use `iree-compile` provided via a snapshot.
-  find_program(_TRANSLATE_TOOL_EXECUTABLE iree-compile)
-  if(_TRANSLATE_TOOL_EXECUTABLE STREQUAL _TRANSLATE_TOOL_EXECUTABLE-NOTFOUND)
+  find_program(_COMPILE_TOOL_EXECUTABLE iree-compile)
+  if(_COMPILE_TOOL_EXECUTABLE STREQUAL _COMPILE_TOOL_EXECUTABLE-NOTFOUND)
     message(FATAL_ERROR "Could not find iree-compile.")
   endif()
 endif()

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -17,17 +17,17 @@ if(IREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE)
       device_vmvx_sync.c
   )
 
-  set(_TRANSLATE_ARGS)
-  list(APPEND _TRANSLATE_ARGS "--iree-input-type=mhlo")
-  list(APPEND _TRANSLATE_ARGS "--iree-mlir-to-vm-bytecode-module")
-  list(APPEND _TRANSLATE_ARGS "--iree-hal-target-backends=vmvx")
-  list(APPEND _TRANSLATE_ARGS "${IREE_SOURCE_DIR}/samples/simple_embedding/simple_embedding_test.mlir")
-  list(APPEND _TRANSLATE_ARGS "-o")
-  list(APPEND _TRANSLATE_ARGS "simple_embedding_test_bytecode_module_vmvx.vmfb")
+  set(_COMPILE_ARGS)
+  list(APPEND _COMPILE_ARGS "--iree-input-type=mhlo")
+  list(APPEND _COMPILE_ARGS "--iree-mlir-to-vm-bytecode-module")
+  list(APPEND _COMPILE_ARGS "--iree-hal-target-backends=vmvx")
+  list(APPEND _COMPILE_ARGS "${IREE_SOURCE_DIR}/samples/simple_embedding/simple_embedding_test.mlir")
+  list(APPEND _COMPILE_ARGS "-o")
+  list(APPEND _COMPILE_ARGS "simple_embedding_test_bytecode_module_vmvx.vmfb")
 
   add_custom_command(
     OUTPUT "simple_embedding_test_bytecode_module_vmvx.vmfb"
-    COMMAND ${_TRANSLATE_TOOL_EXECUTABLE} ${_TRANSLATE_ARGS}
+    COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_COMPILE_ARGS}
   )
 
   set(_GEN_EMBED_ARGS)
@@ -91,23 +91,23 @@ target_sources(sample_embedded_sync
     device_embedded_sync.c
 )
 
-set(_TRANSLATE_ARGS)
-list(APPEND _TRANSLATE_ARGS "--iree-input-type=mhlo")
-list(APPEND _TRANSLATE_ARGS "--iree-mlir-to-vm-bytecode-module")
-list(APPEND _TRANSLATE_ARGS "--iree-hal-target-backends=dylib-llvm-aot")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-target-triple=${IREE_LLVM_TARGET_TRIPLE}")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-target-cpu=${ARM_CPU}")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-target-float-abi=hard")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-debug-symbols=false")
-list(APPEND _TRANSLATE_ARGS "--iree-vm-bytecode-module-strip-source-map=true")
-list(APPEND _TRANSLATE_ARGS "--iree-vm-emit-polyglot-zip=false")
-list(APPEND _TRANSLATE_ARGS "${CMAKE_CURRENT_SOURCE_DIR}/simple_embedding_int_test.mlir")
-list(APPEND _TRANSLATE_ARGS "-o")
-list(APPEND _TRANSLATE_ARGS "simple_embedding_test_module_dylib_arm_32.vmfb")
+set(_COMPILE_ARGS)
+list(APPEND _COMPILE_ARGS "--iree-input-type=mhlo")
+list(APPEND _COMPILE_ARGS "--iree-mlir-to-vm-bytecode-module")
+list(APPEND _COMPILE_ARGS "--iree-hal-target-backends=dylib-llvm-aot")
+list(APPEND _COMPILE_ARGS "--iree-llvm-target-triple=${IREE_LLVM_TARGET_TRIPLE}")
+list(APPEND _COMPILE_ARGS "--iree-llvm-target-cpu=${ARM_CPU}")
+list(APPEND _COMPILE_ARGS "--iree-llvm-target-float-abi=hard")
+list(APPEND _COMPILE_ARGS "--iree-llvm-debug-symbols=false")
+list(APPEND _COMPILE_ARGS "--iree-vm-bytecode-module-strip-source-map=true")
+list(APPEND _COMPILE_ARGS "--iree-vm-emit-polyglot-zip=false")
+list(APPEND _COMPILE_ARGS "${CMAKE_CURRENT_SOURCE_DIR}/simple_embedding_int_test.mlir")
+list(APPEND _COMPILE_ARGS "-o")
+list(APPEND _COMPILE_ARGS "simple_embedding_test_module_dylib_arm_32.vmfb")
 
 add_custom_command(
   OUTPUT "simple_embedding_test_module_dylib_arm_32.vmfb"
-  COMMAND ${_TRANSLATE_TOOL_EXECUTABLE} ${_TRANSLATE_ARGS}
+  COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_COMPILE_ARGS}
 )
 
 set(_GEN_EMBED_ARGS)

--- a/samples/static_library/CMakeLists.txt
+++ b/samples/static_library/CMakeLists.txt
@@ -14,25 +14,25 @@ target_sources(sample_static_library
     create_bytecode_module.c
 )
 
-set(_TRANSLATE_ARGS)
-list(APPEND _TRANSLATE_ARGS "--iree-mlir-to-vm-bytecode-module")
-list(APPEND _TRANSLATE_ARGS "--iree-hal-target-backends=dylib-llvm-aot")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-target-triple=${IREE_LLVM_TARGET_TRIPLE}")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-target-cpu=${ARM_CPU}")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-target-float-abi=hard")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-link-embedded=false")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-link-static")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-static-library-output-path=simple_mul.o")
-list(APPEND _TRANSLATE_ARGS "${IREE_SOURCE_DIR}/samples/static_library/simple_mul.mlir")
-list(APPEND _TRANSLATE_ARGS "-o")
-list(APPEND _TRANSLATE_ARGS "simple_mul.vmfb")
+set(_COMPILE_ARGS)
+list(APPEND _COMPILE_ARGS "--iree-mlir-to-vm-bytecode-module")
+list(APPEND _COMPILE_ARGS "--iree-hal-target-backends=dylib-llvm-aot")
+list(APPEND _COMPILE_ARGS "--iree-llvm-target-triple=${IREE_LLVM_TARGET_TRIPLE}")
+list(APPEND _COMPILE_ARGS "--iree-llvm-target-cpu=${ARM_CPU}")
+list(APPEND _COMPILE_ARGS "--iree-llvm-target-float-abi=hard")
+list(APPEND _COMPILE_ARGS "--iree-llvm-link-embedded=false")
+list(APPEND _COMPILE_ARGS "--iree-llvm-link-static")
+list(APPEND _COMPILE_ARGS "--iree-llvm-static-library-output-path=simple_mul.o")
+list(APPEND _COMPILE_ARGS "${IREE_SOURCE_DIR}/samples/static_library/simple_mul.mlir")
+list(APPEND _COMPILE_ARGS "-o")
+list(APPEND _COMPILE_ARGS "simple_mul.vmfb")
 
 add_custom_command(
   OUTPUT
     ${CMAKE_CURRENT_BINARY_DIR}/simple_mul.h
     ${CMAKE_CURRENT_BINARY_DIR}/simple_mul.o
     ${CMAKE_CURRENT_BINARY_DIR}/simple_mul.vmfb
-  COMMAND ${_TRANSLATE_TOOL_EXECUTABLE} ${_TRANSLATE_ARGS}
+  COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_COMPILE_ARGS}
 )
 
 add_library(simple_mul
@@ -91,25 +91,25 @@ add_ihex(sample_static_library)
 
 add_executable(sample_static_library_c "")
 
-set(_TRANSLATE_ARGS)
-list(APPEND _TRANSLATE_ARGS "--iree-mlir-to-vm-c-module")
-list(APPEND _TRANSLATE_ARGS "--iree-hal-target-backends=dylib-llvm-aot")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-target-triple=${IREE_LLVM_TARGET_TRIPLE}")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-target-cpu=${ARM_CPU}")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-target-float-abi=hard")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-link-embedded=false")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-link-static")
-list(APPEND _TRANSLATE_ARGS "--iree-llvm-static-library-output-path=simple_mul_c_module.o")
-list(APPEND _TRANSLATE_ARGS "${IREE_SOURCE_DIR}/samples/static_library/simple_mul.mlir")
-list(APPEND _TRANSLATE_ARGS "-o")
-list(APPEND _TRANSLATE_ARGS "simple_mul_emitc.h")
+set(_COMPILE_ARGS)
+list(APPEND _COMPILE_ARGS "--iree-mlir-to-vm-c-module")
+list(APPEND _COMPILE_ARGS "--iree-hal-target-backends=dylib-llvm-aot")
+list(APPEND _COMPILE_ARGS "--iree-llvm-target-triple=${IREE_LLVM_TARGET_TRIPLE}")
+list(APPEND _COMPILE_ARGS "--iree-llvm-target-cpu=${ARM_CPU}")
+list(APPEND _COMPILE_ARGS "--iree-llvm-target-float-abi=hard")
+list(APPEND _COMPILE_ARGS "--iree-llvm-link-embedded=false")
+list(APPEND _COMPILE_ARGS "--iree-llvm-link-static")
+list(APPEND _COMPILE_ARGS "--iree-llvm-static-library-output-path=simple_mul_c_module.o")
+list(APPEND _COMPILE_ARGS "${IREE_SOURCE_DIR}/samples/static_library/simple_mul.mlir")
+list(APPEND _COMPILE_ARGS "-o")
+list(APPEND _COMPILE_ARGS "simple_mul_emitc.h")
 
 add_custom_command(
   OUTPUT
     ${CMAKE_CURRENT_BINARY_DIR}/simple_mul_c_module.h
     ${CMAKE_CURRENT_BINARY_DIR}/simple_mul_c_module.o
     ${CMAKE_CURRENT_BINARY_DIR}/simple_mul_emitc.h
-  COMMAND ${_TRANSLATE_TOOL_EXECUTABLE} ${_TRANSLATE_ARGS}
+  COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_COMPILE_ARGS}
 )
 
 add_library(simple_mul_c_module


### PR DESCRIPTION
Whereas `iree-translate` was used before, `iree-compile` is used for
now. This reworks the related variables accordingly.