### PR TITLE
Re-allow unaligned memory access

### DIFF
--- a/build_tools/cmake/arm-none-eabi-gcc.cmake
+++ b/build_tools/cmake/arm-none-eabi-gcc.cmake
@@ -91,7 +91,7 @@ elseif(ARM_CPU STREQUAL "cortex-m55")
 endif()
 
 set(ARM_COMPILER_FLAGS "${ARM_COMPILER_FLAGS} -DIREE_TIME_NOW_FN=\"\{ return 0; \}\" -DIREE_WAIT_UNTIL_FN=wait_until")
-set(ARM_COMPILER_FLAGS "${ARM_COMPILER_FLAGS} -Wl,--gc-sections -ffunction-sections -fdata-sections -mno-unaligned-access")
+set(ARM_COMPILER_FLAGS "${ARM_COMPILER_FLAGS} -Wl,--gc-sections -ffunction-sections -fdata-sections")
 
 if(ARM_CPU STREQUAL "cortex-m55")
   set(IREE_LLVM_TARGET_TRIPLE "armv8.1m.main-pc-linux-elf")


### PR DESCRIPTION
With iree-org/iree@66be12e merged, and the corresponding integrate
commit, the upstream issue iree-org/iree#9593 is solved and the
workaround added with #150 is hence no longer needed.