### PR TITLE
Add a non-EmitC vision inference demo

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -171,6 +171,7 @@ jobs:
           sample_embedded_sync \
           sample_static_library \
           sample_static_library_c \
+          mnist_static_library \
           mnist_static_library_c
 
     - name: Upload CMSIS build artifact for STM32F4xx
@@ -182,6 +183,7 @@ jobs:
           build-cmsis/samples/simple_embedding/sample_embedded_sync.elf
           build-cmsis/samples/static_library/sample_static_library.elf
           build-cmsis/samples/static_library/sample_static_library_c.elf
+          build-cmsis/samples/vision_inference/mnist_static_library.elf
           build-cmsis/samples/vision_inference/mnist_static_library_c.elf
 
     - name: Build with libopencm3 for STM32F4xx

--- a/samples/vision_inference/CMakeLists.txt
+++ b/samples/vision_inference/CMakeLists.txt
@@ -1,4 +1,114 @@
 #-------------------------------------------------------------------------------
+# Model input
+#-------------------------------------------------------------------------------
+
+set(_CONVERT_INPUT_SCRIPT "${CMAKE_SOURCE_DIR}/build_tools/convert-image-to-c-array.py")
+set(_MODEL_INPUT "${IREE_SOURCE_DIR}/samples/vision_inference/mnist_test.png")
+add_custom_command(
+  OUTPUT
+    ${CMAKE_CURRENT_BINARY_DIR}/model_input.h
+  COMMAND
+    ${_CONVERT_INPUT_SCRIPT} ${_MODEL_INPUT} > ${CMAKE_CURRENT_BINARY_DIR}/model_input.h
+  DEPENDS ${_CONVERT_INPUT_SCRIPT} ${_MODEL_INPUT}
+)
+
+add_library(mnist_model_input
+  INTERFACE
+    ${CMAKE_CURRENT_BINARY_DIR}/model_input.h
+)
+
+#-------------------------------------------------------------------------------
+# Vision inference sample
+#-------------------------------------------------------------------------------
+
+# TODO(marbre): Fix building with libopencm3. 
+if(NOT BUILD_WITH_LIBOPENCM3)
+
+  add_executable(mnist_static_library "")
+
+  target_sources(mnist_static_library
+    PRIVATE
+      static_library_mnist.c
+      create_bytecode_module.c
+  )
+
+  set(_COMPILE_ARGS)
+  list(APPEND _COMPILE_ARGS "--iree-input-type=mhlo")
+  list(APPEND _COMPILE_ARGS "--iree-mlir-to-vm-bytecode-module")
+  list(APPEND _COMPILE_ARGS "--iree-hal-target-backends=dylib-llvm-aot")
+  list(APPEND _COMPILE_ARGS "--iree-llvm-target-triple=${IREE_LLVM_TARGET_TRIPLE}")
+  list(APPEND _COMPILE_ARGS "--iree-llvm-target-cpu=${ARM_CPU}")
+  list(APPEND _COMPILE_ARGS "--iree-llvm-target-float-abi=${IREE_LLVM_TARGET_FLOAT_ABI}")
+  list(APPEND _COMPILE_ARGS "--iree-llvm-link-embedded=false")
+  list(APPEND _COMPILE_ARGS "--iree-llvm-link-static")
+  list(APPEND _COMPILE_ARGS "--iree-llvm-static-library-output-path=mnist.o")
+  list(APPEND _COMPILE_ARGS "${IREE_SOURCE_DIR}/samples/models/mnist.mlir")
+  list(APPEND _COMPILE_ARGS "-o")
+  list(APPEND _COMPILE_ARGS "mnist.vmfb")
+
+  add_custom_command(
+    OUTPUT
+      ${CMAKE_CURRENT_BINARY_DIR}/mnist.h
+      ${CMAKE_CURRENT_BINARY_DIR}/mnist.o
+      ${CMAKE_CURRENT_BINARY_DIR}/mnist.vmfb
+    COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_COMPILE_ARGS}
+  )
+
+  add_library(mnist
+    STATIC
+      ${CMAKE_CURRENT_BINARY_DIR}/mnist.o
+  )
+
+  set_target_properties(mnist
+    PROPERTIES
+    LINKER_LANGUAGE C
+  )
+
+  set(_GEN_EMBED_ARGS)
+  list(APPEND _GEN_EMBED_ARGS "--output_header=mnist_c.h")
+  list(APPEND _GEN_EMBED_ARGS "--output_impl=mnist_c.c")
+  list(APPEND _GEN_EMBED_ARGS "--identifier=iree_samples_static_library_mnist")
+  list(APPEND _GEN_EMBED_ARGS "--flatten")
+  list(APPEND _GEN_EMBED_ARGS "mnist.vmfb")
+
+  add_custom_command(
+    OUTPUT
+      "mnist_c.h"
+      "mnist_c.c"
+    COMMAND generate_embed_data ${_GEN_EMBED_ARGS}
+    DEPENDS generate_embed_data mnist.vmfb
+  )
+
+  add_library(mnist_c STATIC "")
+  target_sources(mnist_c
+    PRIVATE
+      mnist_c.c
+      mnist_c.h
+  )
+
+  target_include_directories(mnist_static_library
+    PRIVATE
+      ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+  target_link_libraries(mnist_static_library
+    PRIVATE
+      mnist_c
+      mnist_model_input
+      iree::runtime
+      iree::hal::drivers::local_sync::sync_driver
+      iree::hal::local::loaders::static_library_loader
+      mnist
+      firmware
+      utils
+  )
+
+  add_binary(mnist_static_library)
+  add_ihex(mnist_static_library)
+
+endif()
+
+#-------------------------------------------------------------------------------
 # Vision inference sample, EmitC
 #-------------------------------------------------------------------------------
 
@@ -44,21 +154,6 @@ target_compile_definitions(mnist_c_module
 set_target_properties(mnist_c_module
   PROPERTIES
   LINKER_LANGUAGE C
-)
-
-set(_CONVERT_INPUT_SCRIPT "${CMAKE_SOURCE_DIR}/build_tools/convert-image-to-c-array.py")
-set(_MODEL_INPUT "${IREE_SOURCE_DIR}/samples/vision_inference/mnist_test.png")
-add_custom_command(
-  OUTPUT
-    ${CMAKE_CURRENT_BINARY_DIR}/model_input.h
-  COMMAND
-    ${_CONVERT_INPUT_SCRIPT} ${_MODEL_INPUT} > ${CMAKE_CURRENT_BINARY_DIR}/model_input.h
-  DEPENDS ${_CONVERT_INPUT_SCRIPT} ${_MODEL_INPUT}
-)
-
-add_library(mnist_model_input
-  INTERFACE
-    ${CMAKE_CURRENT_BINARY_DIR}/model_input.h
 )
 
 target_sources(mnist_static_library_c

--- a/samples/vision_inference/create_bytecode_module.c
+++ b/samples/vision_inference/create_bytecode_module.c
@@ -1,0 +1,24 @@
+// Copyright 2021 The IREE Authors
+// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten
+//                Forschung e.V.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#include <stdio.h>
+
+#include "iree/vm/bytecode_module.h"
+#include "mnist_c.h"
+
+// A function to create the bytecode module.
+iree_status_t create_module(iree_vm_module_t** module) {
+  const struct iree_file_toc_t* module_file_toc =
+      iree_samples_static_library_mnist_create();
+  iree_const_byte_span_t module_data =
+      iree_make_const_byte_span(module_file_toc->data, module_file_toc->size);
+
+  return iree_vm_bytecode_module_create(module_data, iree_allocator_null(),
+                                        iree_allocator_system(), module);
+}
+
+void print_success() { printf("mnist_static_library_run passed\n"); }

--- a/tests/mnist_static_library.robot
+++ b/tests/mnist_static_library.robot
@@ -1,0 +1,29 @@
+*** Settings ***
+Suite Setup         Setup
+Suite Teardown      Teardown
+Test Setup          Reset Emulation
+Resource            ${RENODEKEYWORDS}
+Resource            samples.resource
+
+*** Variables ***
+${EXECUTABLE}       vision_inference/mnist_static_library.elf
+
+*** Test Cases ***
+CMSIS
+    Run Sample For Library      cmsis           ${EXECUTABLE}
+    Output Should Show Success
+
+*** Keywords ***
+Output Should Show Success
+    Wait For Line On Uart       Result[0] = 0.000080
+    Wait For Line On Uart       Result[1] = 0.004654
+    Wait For Line On Uart       Result[2] = 0.000726
+    Wait For Line On Uart       Result[3] = 0.000487
+    Wait For Line On Uart       Result[4] = 0.958271
+    Wait For Line On Uart       Result[5] = 0.002669
+    Wait For Line On Uart       Result[6] = 0.011364
+    Wait For Line On Uart       Result[7] = 0.001507
+    Wait For Line On Uart       Result[8] = 0.008866
+    Wait For Line On Uart       Result[9] = 0.011377
+    Wait For Line On Uart       Execution successful!
+    Wait For Line On Uart       mnist_static_library_run passed


### PR DESCRIPTION
Adds a vision inference demo similar to the static library demo that
does not rely on EmitC.