### PR TITLE
Update actions and pin to commit

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - name: Cache Toolchain
       id: cache-toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: ${{ env.TOOLCHAIN }}
         key: ${{ runner.os }}-gcc-arm-${{ env.TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi
@@ -44,7 +44,7 @@ jobs:
     steps:
     - name: Cache Renode
       id: cache-renode
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: |
           ${{ env.VENV_RENODE }}
@@ -67,13 +67,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         path: ${{ env.REPO }}
 
     - name: Cache IREE Snapshot
       id: cache-snapshot
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: |
           ${{ env.VENV_IREE }}
@@ -130,7 +130,7 @@ jobs:
         sudo apt install cmake ninja-build
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         path: ${{ env.REPO }}
         submodules: 'true'
@@ -145,14 +145,14 @@ jobs:
 
     - name: Cache Toolchain
       id: cache-toolchain
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: ${{ env.TOOLCHAIN }}
         key: ${{ runner.os }}-gcc-arm-${{ env.TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi
 
     - name: Cache IREE Snapshot
       id: cache-snapshot
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: |
           ${{ env.VENV_IREE }}
@@ -175,7 +175,7 @@ jobs:
           mnist_static_library_c
 
     - name: Upload CMSIS build artifact for nRF52840
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
       with:
         name: cmsis-nrf52840-build-artifact
         path: |
@@ -202,7 +202,7 @@ jobs:
           mnist_static_library_c
 
     - name: Upload CMSIS build artifact for STM32F4xx
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
       with:
         name: cmsis-stm32f4xx-build-artifact
         path: |
@@ -229,7 +229,7 @@ jobs:
           mnist_static_library_c
 
     - name: Upload libopencm3 build artifact for STM32F4xx
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
       with:
         name: libopencm3-stm32f4xx-build-artifact
         path: |
@@ -247,13 +247,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         path: ${{ env.REPO }}
 
     - name: Cache Renode
       id: cache-renode
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: |
           ${{ env.VENV_RENODE }}
@@ -261,7 +261,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.RENODE }}-${{ env.RENODE_VERSION }}
 
     - name: Download CMSIS build artifact for nRF52840
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
       with:
         name: cmsis-nrf52840-build-artifact
         path: build-cmsis-nrf52840/samples
@@ -272,7 +272,7 @@ jobs:
         ${{ env.RENODE }}/renode-test --variable BASE_DIR:$GITHUB_WORKSPACE --variable TARGET:nrf52840 --exclude NoCI --exclude libopencm3 tests/*.robot
 
     - name: Delete CMSIS build artifact for nRF52840
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # v1.0.0
       with:
         name: cmsis-nrf52840-build-artifact
 
@@ -283,13 +283,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         path: ${{ env.REPO }}
 
     - name: Cache Renode
       id: cache-renode
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: |
           ${{ env.VENV_RENODE }}
@@ -297,13 +297,13 @@ jobs:
         key: ${{ runner.os }}-${{ env.RENODE }}-${{ env.RENODE_VERSION }}
 
     - name: Download CMSIS build artifact for STM32F4xx
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
       with:
         name: cmsis-stm32f4xx-build-artifact
         path: build-cmsis-stm32f4xx/samples
 
     - name: Download libopencm3 build artifact for STM32F4xx
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
       with:
         name: libopencm3-stm32f4xx-build-artifact
         path: build-libopencm3-stm32f4xx/samples
@@ -314,11 +314,11 @@ jobs:
         ${{ env.RENODE }}/renode-test --variable BASE_DIR:$GITHUB_WORKSPACE --variable TARGET:stm32f4xx --exclude NoCI tests/*.robot
 
     - name: Delete CMSIS build artifact for STM32F4xx
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # v1.0.0
       with:
         name: cmsis-stm32f4xx-build-artifact
 
     - name: Delete libopencm3 build artifact for STM32F4xx
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # v1.0.0
       with:
         name: libopencm3-stm32f4xx-build-artifact

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
           wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
           chmod +x /tmp/git-clang-format
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"


### PR DESCRIPTION
This updates the used actions to newer versions and specifies a specific
commit instead of a tag or a branch, which can be overwritten by a
maintainer of the action.