### PR TITLE
Add concurrency groups to pull requests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   TOOLCHAIN: arm-none-eabi
   TOOLCHAIN_VERSION: 11.3.rel1


### PR DESCRIPTION
Cancels in-progress jobs for a current workflow (when pushing
additional commits to a branch that belongs to a PR). The docs suggest
to use the `github.ref`, but it seems that this also cancels workflows
on the main branch if more recent workflows for the main branch get
triggered.

References:
https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request