### PR TITLE
Revise concurrency group id

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Even if the pull request number is used instead of the ref id the
in-progress jobs for a workflow on the main branch gets canceled.
Switching to the more commin ref therefore.