### PR TITLE
Add `PLL_HSI` clock configuration parameters for STM32L4R5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,9 @@ else()
   message(STATUS "Configuring clock source as ${CLOCK_SOURCE}")
 endif()
 
-# We don't support clock sources HSE and PLL_HSE on STM32L476
-if(ARM_TARGET STREQUAL "STM32L476" AND (CLOCK_SOURCE STREQUAL "HSE" OR CLOCK_SOURCE STREQUAL "PLL_HSE"))
-  message(FATAL_ERROR "Clock sources other than HSI and PLL_HSI are not supported on STM32L476")
+# We don't support clock sources HSE and PLL_HSE on STM32L476 and STM32L4R5
+if(ARM_TARGET MATCHES "^STM32L4" AND (CLOCK_SOURCE STREQUAL "HSE" OR CLOCK_SOURCE STREQUAL "PLL_HSE"))
+  message(FATAL_ERROR "Clock sources other than HSI and PLL_HSI are not supported on STM32L476 and STM32L4R5")
 endif()
 
 # Set executable suffix to elf

--- a/utils/stm32l4_cmsis.c
+++ b/utils/stm32l4_cmsis.c
@@ -46,7 +46,7 @@ void clock_setup(void) {
   // Enable power interface clock
   RCC->APB1ENR1 |= RCC_APB1ENR1_PWREN;
 
-  // Configure voltage scaling to scale 3 (higher performance but higher
+  // Configure voltage scaling to range 1 (higher performance but higher
   // consumption)
   PWR->CR1 |= PWR_CR1_VOS;
 

--- a/utils/stm32l4r5xx_cmsis.h
+++ b/utils/stm32l4r5xx_cmsis.h
@@ -8,3 +8,16 @@
 #include "stm32l4r5xx.h"
 
 #define USART_ISR_TXE USART_ISR_TXE_TXFNF
+
+// When using the PLL, the clock needs to be configured accordingly. Adjust
+// these values to your needs.
+
+#define FLASH_WAIT_STATES FLASH_ACR_LATENCY_3WS
+#define AHB_PRESCALER RCC_CFGR_HPRE_DIV1
+#define APB1_PRESCALER RCC_CFGR_PPRE1_DIV1
+#define APB2_PRESCALER RCC_CFGR_PPRE2_DIV1
+#if defined(USE_PLL_HSI_CLOCK)
+#define PLL_M 0  // divides by 1
+#define PLL_N 10
+#define PLL_R 0  // divides by 2
+#endif


### PR DESCRIPTION
This adds the PLL parameters for clock source `PLL_HSI`. I tested the clocks with a basic timer delay (which is not part of this project). We also could measure the clock frequency with an oscilloscope.