### PR TITLE
Update URL to IREE python packages

### DIFF
--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,3 +1,3 @@
--f https://github.com/iree-org/iree/releases/expanded_assets/candidate-20221010.292
+-f https://iree-org.github.io/iree/pip-release-links.html
 iree-tools-tf==20221010.292
 iree-tools-tflite==20221010.292

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
--f https://github.com/iree-org/iree/releases/expanded_assets/candidate-20221010.292
+-f https://iree-org.github.io/iree/pip-release-links.html
 iree-compiler==20221010.292
 Pillow


### PR DESCRIPTION
Sets the URL to the index page instead of using the GitHub generated page, see the PSA
https://groups.google.com/g/iree-discuss/c/tFX79TEAWSM