### PR TITLE
Switch to `IREE_HOST_BIN_DIR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ cd build
 # export PATH_TO_LINKER_SCRIPT="`realpath ../third_party/libopencm3-custom/stm32f407xg.ld`"
 
 
-# export PATH_TO_IREE_HOST_BINARY_ROOT="`realpath ../build-iree-host-install`"
+# export PATH_TO_IREE_HOST_BIN_DIR="`realpath ../build-iree-host-install/bin`"
 
 cmake -GNinja \
 #     -DBUILD_WITH_CMSIS=ON \
@@ -217,7 +217,7 @@ cmake -GNinja \
       -DIREE_HAL_DRIVER_LOCAL_SYNC=ON \
       -DIREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF=ON \
       -DIREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE=ON \
-      -DIREE_HOST_BINARY_ROOT="${PATH_TO_IREE_HOST_BINARY_ROOT}" \
+      -DIREE_HOST_BIN_DIR="${PATH_TO_IREE_HOST_BIN_DIR}" \
       -DCUSTOM_ARM_LINKER_FLAGS="${CUSTOM_ARM_LINKER_FLAGS}" \
       -DLINKER_SCRIPT="${PATH_TO_LINKER_SCRIPT}" \
 #     -DUSE_UART1=ON \

--- a/build_tools/configure_build.sh
+++ b/build_tools/configure_build.sh
@@ -152,7 +152,7 @@ case $2 in
 esac
 
 # Set the path to the IREE host binary
-export PATH_TO_IREE_HOST_BINARY_ROOT="`realpath ../build-iree-host-install`"
+export PATH_TO_IREE_HOST_BIN_DIR="`realpath ../build-iree-host-install/bin`"
 
 # Check paths
 if ! [ -f "$PATH_TO_LINKER_SCRIPT" ]; then
@@ -160,8 +160,8 @@ if ! [ -f "$PATH_TO_LINKER_SCRIPT" ]; then
   exit 1
 fi
 
-if ! [ -d "$PATH_TO_IREE_HOST_BINARY_ROOT/bin/" ]; then
-  echo "Expected the path to IREE host binary to be set correctly (got '$PATH_TO_IREE_HOST_BINARY_ROOT'): can't find bin subdirectory"
+if ! [ -d "$PATH_TO_IREE_HOST_BIN_DIR" ]; then
+  echo "Expected the path to IREE host binary to be set correctly (got '$PATH_TO_IREE_HOST_BIN_DIR'): can't find directory"
   exit 1
 fi
 
@@ -176,7 +176,7 @@ cmake -GNinja \
       -DIREE_HAL_DRIVER_LOCAL_SYNC=ON \
       -DIREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF=ON \
       -DIREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE=ON \
-      -DIREE_HOST_BINARY_ROOT="${PATH_TO_IREE_HOST_BINARY_ROOT}" \
+      -DIREE_HOST_BIN_DIR="${PATH_TO_IREE_HOST_BIN_DIR}" \
       -DCUSTOM_ARM_LINKER_FLAGS="${CUSTOM_ARM_LINKER_FLAGS}" \
       -DLINKER_SCRIPT="${PATH_TO_LINKER_SCRIPT}" \
       -DUSE_UART${UART}=ON \

--- a/build_tools/install_iree_host_tools.sh
+++ b/build_tools/install_iree_host_tools.sh
@@ -45,7 +45,7 @@ fi
 echo "Installing IREE host tools candidate-${IREE_VERSION}"
 
 
-# Create the IREE_HOST_BINARY_ROOT directory
+# Create the IREE_HOST_BIN_DIR directory
 
 mkdir -p build-iree-host-install-${IREE_VERSION}/bin
 ln -sfn build-iree-host-install-${IREE_VERSION} build-iree-host-install

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -26,9 +26,9 @@ endif()
 
 add_library(firmware ALIAS ${CONDITIONAL_DEP})
 
-if(EXISTS ${IREE_HOST_BINARY_ROOT}/bin/iree-compile)
-  # Use `iree-compile` if installed to IREE_HOST_BINARY_ROOT.
-  set(_COMPILE_TOOL_EXECUTABLE ${IREE_HOST_BINARY_ROOT}/bin/iree-compile)
+if(EXISTS ${IREE_HOST_BIN_DIR}/iree-compile)
+  # Use `iree-compile` if installed to IREE_HOST_BIN_DIR.
+  set(_COMPILE_TOOL_EXECUTABLE ${IREE_HOST_BIN_DIR}/iree-compile)
 else()
   # Use `iree-compile` provided via a snapshot.
   find_program(_COMPILE_TOOL_EXECUTABLE iree-compile)


### PR DESCRIPTION
`IREE_HOST_BINARY_ROOT` is deprecated and should be replaced by `IREE_HOST_BIN_DIR`. Depends on #239.