### PR TITLE
Switch from mhlo to arith ops

### DIFF
--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -18,7 +18,6 @@ if(IREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE)
   )
 
   set(_COMPILE_ARGS)
-  list(APPEND _COMPILE_ARGS "--iree-input-type=mhlo")
   list(APPEND _COMPILE_ARGS "--output-format=vm-bytecode")
   list(APPEND _COMPILE_ARGS "--iree-hal-target-backends=vmvx")
   list(APPEND _COMPILE_ARGS "${IREE_SOURCE_DIR}/samples/simple_embedding/simple_embedding_test.mlir")
@@ -93,7 +92,6 @@ target_sources(sample_embedded_sync
 )
 
 set(_COMPILE_ARGS)
-list(APPEND _COMPILE_ARGS "--iree-input-type=mhlo")
 list(APPEND _COMPILE_ARGS "--output-format=vm-bytecode")
 list(APPEND _COMPILE_ARGS "--iree-hal-target-backends=llvm-cpu")
 list(APPEND _COMPILE_ARGS "--iree-llvm-target-triple=${IREE_LLVM_TARGET_TRIPLE}")

--- a/samples/simple_embedding/simple_embedding_int_test.mlir
+++ b/samples/simple_embedding/simple_embedding_int_test.mlir
@@ -1,5 +1,5 @@
 func.func @simple_mul(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> tensor<4xi32>
     {
-  %0 = "mhlo.multiply"(%arg0, %arg1) {name = "mul.1"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+  %0 = "arith.muli"(%arg0, %arg1) : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
   return %0 : tensor<4xi32>
 }


### PR DESCRIPTION
Upstream switched the input `simple_embedding_test.mlir` from mhlo to arith ops some time ago. We will test mhlo ops with simple_vec_mul example that will be added in a follow up shortly.