### PR TITLE
Drop unused argument

### DIFF
--- a/samples/simple_vec_mul/CMakeLists.txt
+++ b/samples/simple_vec_mul/CMakeLists.txt
@@ -230,8 +230,6 @@ static_module(
     simple_mul_int_bytecode_module_static_c_module
   SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/simple_mul_int.mlir"
-  C_IDENTIFIER
-    "simple_mul_int"
   FLAGS
     "--iree-input-type=mhlo"
   EMITC
@@ -274,8 +272,6 @@ static_module(
     simple_mul_int_bytecode_module_static_inline_c_module
   SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/simple_mul_int.mlir"
-  C_IDENTIFIER
-    "simple_mul_int"
   FLAGS
     "--iree-input-type=mhlo"
   EMITC


### PR DESCRIPTION
The C identifier does not need to be specified if building with EmitC.