### PR TITLE
Explicitly license under CC0-1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-License-Identifier: CC0-1.0
+
 [submodule "third_party/iree"]
 	path = third_party/iree
 	url = https://github.com/openxla/iree.git

--- a/iree-release-link.txt.license
+++ b/iree-release-link.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+SPDX-License-Identifier: CC0-1.0

--- a/requirements-compiler.txt
+++ b/requirements-compiler.txt
@@ -1,2 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-License-Identifier: CC0-1.0
 -f https://openxla.github.io/iree/pip-release-links.html
 iree-compiler==20230623.561

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-License-Identifier: CC0-1.0
 -f https://openxla.github.io/iree/pip-release-links.html
 iree-tools-tf==20230623.561
 iree-tools-tflite==20230623.561

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-License-Identifier: CC0-1.0
 numpy
 Pillow


### PR DESCRIPTION
These files are not particularly copyrightable. Thus they are now explicitly (re-)licensed under CC0-1.0, as suggested by REUSE, see https://reuse.software/tutorial/#insignificant-files.