### PR TITLE
Integrate IREE at openxla/iree@48f7394

### DIFF
--- a/iree-release-link.txt
+++ b/iree-release-link.txt
@@ -1,1 +1,1 @@
-https://github.com/openxla/iree/releases/download/candidate-20230803.602/iree-dist-20230803.602-linux-x86_64.tar.xz
+https://github.com/openxla/iree/releases/download/candidate-20230815.614/iree-dist-20230815.614-linux-x86_64.tar.xz

--- a/requirements-compiler.txt
+++ b/requirements-compiler.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 # SPDX-License-Identifier: CC0-1.0
 -f https://openxla.github.io/iree/pip-release-links.html
-iree-compiler==20230803.602
+iree-compiler==20230815.614

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 # SPDX-License-Identifier: CC0-1.0
 -f https://openxla.github.io/iree/pip-release-links.html
-iree-tools-tf==20230803.602
-iree-tools-tflite==20230803.602
+iree-tools-tf==20230815.614
+iree-tools-tflite==20230815.614


### PR DESCRIPTION
Updates IREE usage to match openxla/iree@48f7394 and candidate-20230815.614, respectively.