### PR TITLE
Update GitHub Actions and set retention period

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - name: Cache Toolchain
       id: cache-toolchain
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3.2.3
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ${{ env.TOOLCHAIN }}
         key: ${{ runner.os }}-arm-gnu-toolchain-${{ env.TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi
@@ -54,7 +54,7 @@ jobs:
     steps:
     - name: Cache Renode
       id: cache-renode
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3.2.3
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: |
           ${{ env.VENV_RENODE }}
@@ -77,13 +77,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: ${{ env.REPO }}
 
     - name: Cache IREE Snapshot
       id: cache-snapshot
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3.2.3
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: |
           ${{ env.VENV_IREE }}
@@ -120,7 +120,7 @@ jobs:
         sudo apt install cmake ninja-build
 
     - name: Checkout repository
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: ${{ env.REPO }}
         submodules: 'false'
@@ -143,14 +143,14 @@ jobs:
 
     - name: Cache Toolchain
       id: cache-toolchain
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3.2.3
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ${{ env.TOOLCHAIN }}
         key: ${{ runner.os }}-arm-gnu-toolchain-${{ env.TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi
 
     - name: Cache IREE Snapshot
       id: cache-snapshot
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3.2.3
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: |
           ${{ env.VENV_IREE }}
@@ -167,7 +167,7 @@ jobs:
         cmake --build . --target all
 
     - name: Upload CMSIS build artifact for nRF52840
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: cmsis-nrf52840-build-artifact
         path: |
@@ -183,6 +183,7 @@ jobs:
           build-cmsis-nrf52840/samples/static_library/sample_static_library_c.elf
           build-cmsis-nrf52840/samples/vision_inference/mnist_static_library.elf
           build-cmsis-nrf52840/samples/vision_inference/mnist_static_library_c.elf
+        retention-days: 1
 
     - name: Build with CMSIS for STM32F4xx
       run: |
@@ -194,7 +195,7 @@ jobs:
         cmake --build . --target all
 
     - name: Upload CMSIS build artifact for STM32F4xx
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: cmsis-stm32f4xx-build-artifact
         path: |
@@ -210,6 +211,7 @@ jobs:
           build-cmsis-stm32f4xx/samples/static_library/sample_static_library_c.elf
           build-cmsis-stm32f4xx/samples/vision_inference/mnist_static_library.elf
           build-cmsis-stm32f4xx/samples/vision_inference/mnist_static_library_c.elf
+        retention-days: 1
 
     - name: Build with libopencm3 for STM32F4xx
       run: |
@@ -221,7 +223,7 @@ jobs:
         cmake --build . --target all
 
     - name: Upload libopencm3 build artifact for STM32F4xx
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: libopencm3-stm32f4xx-build-artifact
         path: |
@@ -237,6 +239,7 @@ jobs:
           build-libopencm3-stm32f4xx/samples/static_library/sample_static_library_c.elf
           build-libopencm3-stm32f4xx/samples/vision_inference/mnist_static_library.elf
           build-libopencm3-stm32f4xx/samples/vision_inference/mnist_static_library_c.elf
+        retention-days: 1
 
     - name: Build with CMSIS for STM32L4R5
       run: |
@@ -248,7 +251,7 @@ jobs:
         cmake --build . --target all
 
     - name: Upload CMSIS build artifact for STM32L4R5
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: cmsis-stm32l4r5-build-artifact
         path: |
@@ -264,6 +267,7 @@ jobs:
           build-cmsis-stm32l4r5/samples/static_library/sample_static_library_c.elf
           build-cmsis-stm32l4r5/samples/vision_inference/mnist_static_library.elf
           build-cmsis-stm32l4r5/samples/vision_inference/mnist_static_library_c.elf
+        retention-days: 1
 
   test-nrf52840:
     name: Test Samples (nRF52840)
@@ -272,13 +276,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: ${{ env.REPO }}
 
     - name: Cache Renode
       id: cache-renode
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3.2.3
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: |
           ${{ env.VENV_RENODE }}
@@ -286,7 +290,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.RENODE }}-${{ env.RENODE_VERSION }}
 
     - name: Download CMSIS build artifact for nRF52840
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
       with:
         name: cmsis-nrf52840-build-artifact
         path: build-cmsis-nrf52840/samples
@@ -296,11 +300,6 @@ jobs:
         source ${{ env.VENV_RENODE }}/bin/activate
         ${{ env.RENODE }}/renode-test --variable BASE_DIR:$GITHUB_WORKSPACE --variable TARGET:nrf52840 --exclude NoCI --exclude libopencm3 --exclude xfail-nrf52840 tests/*.robot
 
-    - name: Delete CMSIS build artifact for nRF52840
-      uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # v2.0.0
-      with:
-        name: cmsis-nrf52840-build-artifact
-
   test-stm32f4:
     name: Test Samples (STM32F4xx)
     needs: [install-renode, build]
@@ -308,13 +307,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: ${{ env.REPO }}
 
     - name: Cache Renode
       id: cache-renode
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3.2.3
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: |
           ${{ env.VENV_RENODE }}
@@ -322,13 +321,13 @@ jobs:
         key: ${{ runner.os }}-${{ env.RENODE }}-${{ env.RENODE_VERSION }}
 
     - name: Download CMSIS build artifact for STM32F4xx
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
       with:
         name: cmsis-stm32f4xx-build-artifact
         path: build-cmsis-stm32f4xx/samples
 
     - name: Download libopencm3 build artifact for STM32F4xx
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
       with:
         name: libopencm3-stm32f4xx-build-artifact
         path: build-libopencm3-stm32f4xx/samples
@@ -338,16 +337,6 @@ jobs:
         source ${{ env.VENV_RENODE }}/bin/activate
         ${{ env.RENODE }}/renode-test --variable BASE_DIR:$GITHUB_WORKSPACE --variable TARGET:stm32f4xx --exclude NoCI tests/*.robot
 
-    - name: Delete CMSIS build artifact for STM32F4xx
-      uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # v2.0.0
-      with:
-        name: cmsis-stm32f4xx-build-artifact
-
-    - name: Delete libopencm3 build artifact for STM32F4xx
-      uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # v2.0.0
-      with:
-        name: libopencm3-stm32f4xx-build-artifact
-
   test-stm32l4r5:
     name: Test Samples (STM32L4R5)
     needs: [install-renode, build]
@@ -355,13 +344,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: ${{ env.REPO }}
 
     - name: Cache Renode
       id: cache-renode
-      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3.2.3
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: |
           ${{ env.VENV_RENODE }}
@@ -369,7 +358,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.RENODE }}-${{ env.RENODE_VERSION }}
 
     - name: Download CMSIS build artifact for STM32L4R5
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
       with:
         name: cmsis-stm32l4r5-build-artifact
         path: build-cmsis-stm32l4r5/samples
@@ -378,8 +367,3 @@ jobs:
       run: |
         source ${{ env.VENV_RENODE }}/bin/activate
         ${{ env.RENODE }}/renode-test --variable BASE_DIR:$GITHUB_WORKSPACE --variable TARGET:stm32l4r5 --exclude NoCI --exclude libopencm3 tests/*.robot
-
-    - name: Delete CMSIS build artifact for STM32L4R5
-      uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # v2.0.0
-      with:
-        name: cmsis-stm32l4r5-build-artifact

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
           wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
           chmod +x /tmp/git-clang-format
       - name: Checking out repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -12,6 +12,6 @@ jobs:
   reuse:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@4f2804894b54004c8ed4b8a62b7c649e54a3aa4b # v2.0.0


### PR DESCRIPTION
* Updates actions/cache to v4.0.0
* Updates actions/checkout to v4.1.1
* Updates actions/upload-artifact to v4.3.1
* Updates actions/download-artifact to v4.1.2

Instead of deleting artifacts, the retention period for artifacts is set
to one day.