### PR TITLE
Integrate IREE at openxla/iree@d33f216

### DIFF
--- a/iree-release-link.txt
+++ b/iree-release-link.txt
@@ -1,1 +1,1 @@
-https://github.com/openxla/iree/releases/download/candidate-20240310.826/iree-dist-20240310.826-linux-x86_64.tar.xz
+https://github.com/openxla/iree/releases/download/candidate-20240404.852/iree-dist-20240404.852-linux-x86_64.tar.xz

--- a/requirements-compiler.txt
+++ b/requirements-compiler.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 # SPDX-License-Identifier: CC0-1.0
 -f https://openxla.github.io/iree/pip-release-links.html
-iree-compiler==20240310.826
+iree-compiler==20240404.852

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 # SPDX-License-Identifier: CC0-1.0
 -f https://openxla.github.io/iree/pip-release-links.html
-iree-tools-tf==20240310.826
-iree-tools-tflite==20240310.826
+iree-tools-tf==20240404.852
+iree-tools-tflite==20240404.852


### PR DESCRIPTION
Updates IREE usage to match openxla/iree@d33f216 and candidate-20240404.852, respectively.