### PR TITLE
Use stable URL for IREE pip-release-links.

### DIFF
--- a/requirements-compiler.txt
+++ b/requirements-compiler.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 # SPDX-License-Identifier: CC0-1.0
--f https://openxla.github.io/iree/pip-release-links.html
+-f https://iree.dev/pip-release-links.html
 iree-compiler==20240404.852

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 # SPDX-License-Identifier: CC0-1.0
--f https://openxla.github.io/iree/pip-release-links.html
+-f https://iree.dev/pip-release-links.html
 iree-tools-tf==20240404.852
 iree-tools-tflite==20240404.852


### PR DESCRIPTION
The `openxla.github.io` link depends on a specific GitHub organization, and the IREE repo will be moving soon (multiple times). The `iree.dev` release links URL is recommended here: https://iree.dev/reference/bindings/python/#prebuilt-packages