### PR TITLE
Integrate IREE at openxla/iree@8735b2e

### DIFF
--- a/iree-release-link.txt
+++ b/iree-release-link.txt
@@ -1,1 +1,1 @@
-https://github.com/iree-org/iree/releases/download/candidate-20240404.852/iree-dist-20240404.852-linux-x86_64.tar.xz
+https://github.com/iree-org/iree/releases/download/candidate-20240429.878/iree-dist-20240429.878-linux-x86_64.tar.xz

--- a/requirements-compiler.txt
+++ b/requirements-compiler.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 # SPDX-License-Identifier: CC0-1.0
 -f https://iree.dev/pip-release-links.html
-iree-compiler==20240404.852
+iree-compiler==20240429.878

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 # SPDX-License-Identifier: CC0-1.0
 -f https://iree.dev/pip-release-links.html
-iree-tools-tf==20240404.852
-iree-tools-tflite==20240404.852
+iree-tools-tf==20240429.878
+iree-tools-tflite==20240429.878


### PR DESCRIPTION
Updates IREE usage to match openxla/iree@8735b2e and candidate-20240429.878, respectively.