### PR TITLE
Introduce AUTHORS file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 BasedOnStyle: Google
 CommentPragmas: '^ SPDX-*|^ Copyright'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 name: Build and Test

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: CC0-1.0
 
 name: REUSE Compliance Check

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Build artifacts

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: CC0-1.0
 
 [submodule "third_party/iree"]

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 The IREE bare-metal Arm Authors
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is the list of IREE bare-metal Arm project's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code.
+# To see the full list of contributors, see the revision history in source
+# control.
+#
+# Please only add individuals if they are not contributing on behalf of a
+# company (who should be listed instead). Add new entries at the bottom of the
+# file.
+
+Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. for its Fraunhofer Institute for Material Flow and Logistics (IML)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 # IREE Bare-Metal Arm Sample

--- a/build_tools/README.md
+++ b/build_tools/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 # Build Tools

--- a/build_tools/cmake/add_binary.cmake
+++ b/build_tools/cmake/add_binary.cmake
@@ -1,4 +1,4 @@
-# Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/cmake/add_ihex.cmake
+++ b/build_tools/cmake/add_ihex.cmake
@@ -1,4 +1,4 @@
-# Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/cmake/arm-none-eabi-gcc.cmake
+++ b/build_tools/cmake/arm-none-eabi-gcc.cmake
@@ -1,4 +1,4 @@
-# Copyright 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright 2021 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build_tools/cmake/static_module.cmake
+++ b/build_tools/cmake/static_module.cmake
@@ -1,4 +1,4 @@
-# Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright 2023 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/cmake/vmvx_module.cmake
+++ b/build_tools/cmake/vmvx_module.cmake
@@ -1,4 +1,4 @@
-# Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright 2023 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/configure_build.sh
+++ b/build_tools/configure_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright 2021 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/convert-image-to-c-array.py
+++ b/build_tools/convert-image-to-c-array.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/build_tools/install_iree_host_tools.sh
+++ b/build_tools/install_iree_host_tools.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/platform_parsed.patch
+++ b/build_tools/platform_parsed.patch
@@ -2,7 +2,7 @@ Explicitly copy .got and .got.plt section.
 
 Authored-by: Marius Brehler <marius.brehler@iml.fraunhofer.de>
 
-SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 SPDX-License-Identifier: Apache-2.0
 --- a/platform_parsed.ld
 +++ b/platform_parsed.ld

--- a/build_tools/stm32l4r5xi-cmsis.ld
+++ b/build_tools/stm32l4r5xi-cmsis.ld
@@ -4,8 +4,7 @@
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
- * Copyright     2022      Fraunhofer-Gesellschaft zur Förderung der
- *                         angewandten Forschung e.V.
+ * Copyright     2022      The IREE bare-metal Arm Authors
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/build_tools/third_party/cmsis_device_f4/CMakeLists.txt
+++ b/build_tools/third_party/cmsis_device_f4/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/third_party/cmsis_device_f7/CMakeLists.txt
+++ b/build_tools/third_party/cmsis_device_f7/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/third_party/cmsis_device_h7/CMakeLists.txt
+++ b/build_tools/third_party/cmsis_device_h7/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.h7a3xx

--- a/build_tools/third_party/cmsis_device_l4/CMakeLists.txt
+++ b/build_tools/third_party/cmsis_device_l4/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/third_party/ethos-u-core-platform/CMakeLists.txt
+++ b/build_tools/third_party/ethos-u-core-platform/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/third_party/libopencm3/CMakeLists.txt
+++ b/build_tools/third_party/libopencm3/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 #
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/build_tools/third_party/nrfx/CMakeLists.txt
+++ b/build_tools/third_party/nrfx/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/update_iree_submodules.sh
+++ b/build_tools/update_iree_submodules.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 ## Getting Started

--- a/iree-release-link.txt.license
+++ b/iree-release-link.txt.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 SPDX-License-Identifier: CC0-1.0

--- a/requirements-compiler.txt
+++ b/requirements-compiler.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: CC0-1.0
 -f https://iree.dev/pip-release-links.html
 iree-compiler==20240728.968

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: CC0-1.0
 -f https://iree.dev/pip-release-links.html
 iree-tools-tf==20240728.968

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: CC0-1.0
 numpy
 Pillow

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/samples/simple_embedding/simple_embedding_int_test.mlir
+++ b/samples/simple_embedding/simple_embedding_int_test.mlir
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 func.func @simple_mul(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> tensor<4xi32>

--- a/samples/simple_vec_mul/CMakeLists.txt
+++ b/samples/simple_vec_mul/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/samples/simple_vec_mul/device_static_sync.c
+++ b/samples/simple_vec_mul/device_static_sync.c
@@ -1,4 +1,4 @@
-// Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2023 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/simple_vec_mul/device_vmvx_sync.c
+++ b/samples/simple_vec_mul/device_vmvx_sync.c
@@ -1,5 +1,5 @@
 // Copyright 2021 The IREE Authors
-// Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2023 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/simple_vec_mul/simple_mul_int.c
+++ b/samples/simple_vec_mul/simple_mul_int.c
@@ -1,5 +1,5 @@
 // Copyright 2021 The IREE Authors
-// Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2023 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/simple_vec_mul/simple_mul_int.mlir
+++ b/samples/simple_vec_mul/simple_mul_int.mlir
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 func.func @simple_mul(%arg0: tensor<1024xi32>, %arg1: tensor<1024xi32>) -> tensor<1024xi32>

--- a/samples/simple_vec_mul/simple_mul_int_bytecode.c
+++ b/samples/simple_vec_mul/simple_mul_int_bytecode.c
@@ -1,4 +1,4 @@
-// Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2023 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/simple_vec_mul/simple_mul_int_c_module.c
+++ b/samples/simple_vec_mul/simple_mul_int_c_module.c
@@ -1,5 +1,5 @@
 // Copyright 2021 The IREE Authors
-// Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2023 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/simple_vec_mul/simple_mul_int_vmvx.c
+++ b/samples/simple_vec_mul/simple_mul_int_vmvx.c
@@ -1,4 +1,4 @@
-// Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2023 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/static_library/CMakeLists.txt
+++ b/samples/static_library/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/samples/vision_inference/CMakeLists.txt
+++ b/samples/vision_inference/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/samples/vision_inference/create_bytecode_module.c
+++ b/samples/vision_inference/create_bytecode_module.c
@@ -1,5 +1,5 @@
 // Copyright 2021 The IREE Authors
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/vision_inference/create_c_module.c
+++ b/samples/vision_inference/create_c_module.c
@@ -1,5 +1,5 @@
 // Copyright 2021 The IREE Authors
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/samples/vision_inference/static_library_mnist.c
+++ b/samples/vision_inference/static_library_mnist.c
@@ -1,5 +1,5 @@
 // Copyright 2021 The IREE Authors
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/tests/mnist_static_library.robot
+++ b/tests/mnist_static_library.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/mnist_static_library_c.robot
+++ b/tests/mnist_static_library_c.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/nrf52840.resource
+++ b/tests/nrf52840.resource
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/sample_embedded_sync.robot
+++ b/tests/sample_embedded_sync.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/sample_static_library.robot
+++ b/tests/sample_static_library.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/sample_static_library_c.robot
+++ b/tests/sample_static_library_c.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/sample_vmvx_sync.robot
+++ b/tests/sample_vmvx_sync.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/simple_vec_mul_int_bytecode_static.robot
+++ b/tests/simple_vec_mul_int_bytecode_static.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/simple_vec_mul_int_bytecode_static_c.robot
+++ b/tests/simple_vec_mul_int_bytecode_static_c.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/simple_vec_mul_int_bytecode_static_inline.robot
+++ b/tests/simple_vec_mul_int_bytecode_static_inline.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/simple_vec_mul_int_bytecode_static_inline_c.robot
+++ b/tests/simple_vec_mul_int_bytecode_static_inline_c.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/simple_vec_mul_int_bytecode_vmvx.robot
+++ b/tests/simple_vec_mul_int_bytecode_vmvx.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/simple_vec_mul_int_bytecode_vmvx_inline.robot
+++ b/tests/simple_vec_mul_int_bytecode_vmvx_inline.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/stm32f4xx.resource
+++ b/tests/stm32f4xx.resource
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/stm32l4r5.resource
+++ b/tests/stm32l4r5.resource
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/tests/vmvx_sample.robot
+++ b/tests/vmvx_sample.robot
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 *** Settings ***

--- a/third_party/.clang-format
+++ b/third_party/.clang-format
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2024 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Disable formatting any code in the `third_party` subdirectory.

--- a/third_party/libopencm3-custom/README.md
+++ b/third_party/libopencm3-custom/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 SPDX-License-Identifier: LGPL-3.0-or-later
 -->
 # LibOpenCM3

--- a/third_party/libopencm3-custom/cortex-m-generic.ld
+++ b/third_party/libopencm3-custom/cortex-m-generic.ld
@@ -2,8 +2,7 @@
  * This file is part of the libopencm3 project.
  *
  * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
- * Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten
- *                Forschung e.V.
+ * Copyright 2022 The IREE bare-metal Arm Authors
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/third_party/libopencm3-custom/fini.c
+++ b/third_party/libopencm3-custom/fini.c
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten
- *                Forschung e.V.
+ * Copyright 2023 The IREE bare-metal Arm Authors
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/third_party/libopencm3-custom/stm32f4xxxx.ld
+++ b/third_party/libopencm3-custom/stm32f4xxxx.ld
@@ -1,7 +1,7 @@
 /*
  * This file is intended to be used with the libopencm3 project.
  *
- * Copyright 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright 2021 The IREE bare-metal Arm Authors
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/third_party/libopencm3-custom/vector.c
+++ b/third_party/libopencm3-custom/vector.c
@@ -3,8 +3,7 @@
  *
  * Copyright (C) 2010 Piotr Esden-Tempski <piotr@esden.net>,
  * Copyright (C) 2012 chrysn <chrysn@fsfe.org>
- * Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten
- *                Forschung e.V.
+ * Copyright 2022 The IREE bare-metal Arm Authors
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/third_party/nrfx-custom/README.md
+++ b/third_party/nrfx-custom/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+SPDX-FileCopyrightText: 2023 The IREE bare-metal Arm Authors
 SPDX-License-Identifier: BSD-3-Clause
 -->
 # nrfx

--- a/third_party/nrfx-custom/gcc_startup_nrf52840.S
+++ b/third_party/nrfx-custom/gcc_startup_nrf52840.S
@@ -1,7 +1,7 @@
 /*
  
 Copyright (c) 2009-2023 ARM Limited. All rights reserved.
-Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+Copyright 2023 The IREE bare-metal Arm Authors
 
     SPDX-License-Identifier: Apache-2.0
 

--- a/third_party/nrfx-custom/gcc_startup_nrf5340_application.S
+++ b/third_party/nrfx-custom/gcc_startup_nrf5340_application.S
@@ -1,7 +1,7 @@
 /*
  
 Copyright (c) 2009-2023 ARM Limited. All rights reserved.
-Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+Copyright 2023 The IREE bare-metal Arm Authors
 
     SPDX-License-Identifier: Apache-2.0
 

--- a/third_party/nrfx-custom/nrf_common.ld
+++ b/third_party/nrfx-custom/nrf_common.ld
@@ -4,7 +4,7 @@
  * Support: https://support.codesourcery.com/GNUToolchain/
  *
  * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
- * Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright 2023 The IREE bare-metal Arm Authors
  * SPDX-License-Identifier: LicenseRef-nrf-common
  *
  * The authors hereby grant permission to use, copy, modify, distribute,

--- a/third_party/nrfx-custom/nrfx_config.h
+++ b/third_party/nrfx-custom/nrfx_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 - 2023, Nordic Semiconductor ASA
- * Copyright 2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright 2024 The IREE bare-metal Arm Authors
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/third_party/nrfx-custom/nrfx_glue.h
+++ b/third_party/nrfx-custom/nrfx_glue.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 - 2023, Nordic Semiconductor ASA
- * Copyright 2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright 2024 The IREE bare-metal Arm Authors
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause

--- a/third_party/renode/README.md
+++ b/third_party/renode/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 SPDX-License-Identifier: MIT
 -->
 # Renode

--- a/third_party/renode/nrf52840.repl
+++ b/third_party/renode/nrf52840.repl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 // SPDX-License-Identifier: MIT
 
 using "platforms/cpus/nrf52840.repl"

--- a/third_party/renode/nrf52840.resc
+++ b/third_party/renode/nrf52840.resc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: MIT
 
 :name: nRF52840

--- a/third_party/renode/stm32f407.repl
+++ b/third_party/renode/stm32f407.repl
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Antmicro <www.antmicro.com>
-// SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 // SPDX-License-Identifier: MIT
 
 using "platforms/boards/stm32f4_discovery.repl"

--- a/third_party/renode/stm32f407.resc
+++ b/third_party/renode/stm32f407.resc
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Antmicro <www.antmicro.com>
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: MIT
 
 :name: STM32F407

--- a/third_party/renode/stm32f446.repl
+++ b/third_party/renode/stm32f446.repl
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Antmicro <www.antmicro.com>
-// SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 // SPDX-License-Identifier: MIT
 
 flash: Memory.MappedMemory @ sysbus 0x08000000

--- a/third_party/renode/stm32f446.resc
+++ b/third_party/renode/stm32f446.resc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: MIT
 
 :name: STM32F446

--- a/third_party/renode/stm32f4xx-highmem.repl
+++ b/third_party/renode/stm32f4xx-highmem.repl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 // SPDX-License-Identifier: MIT
 
 using "platforms/boards/stm32f4_discovery.repl"

--- a/third_party/renode/stm32f4xx-highmem.resc
+++ b/third_party/renode/stm32f4xx-highmem.resc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2021 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: MIT
 
 :name: STM32F4XX

--- a/third_party/renode/stm32f746.repl
+++ b/third_party/renode/stm32f746.repl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 // SPDX-License-Identifier: MIT
 
 using "platforms/boards/stm32f7_discovery-bb.repl"

--- a/third_party/renode/stm32f746.resc
+++ b/third_party/renode/stm32f746.resc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: MIT
 
 :name: STM32F746

--- a/third_party/renode/stm32l476.repl
+++ b/third_party/renode/stm32l476.repl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 // SPDX-License-Identifier: MIT
 
 flash: Memory.MappedMemory @ sysbus 0x08000000

--- a/third_party/renode/stm32l476.resc
+++ b/third_party/renode/stm32l476.resc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: MIT
 
 :name: STM32L476

--- a/third_party/renode/stm32l4r5.repl
+++ b/third_party/renode/stm32l4r5.repl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 // SPDX-License-Identifier: MIT
 
 flash: Memory.MappedMemory @ sysbus 0x08000000

--- a/third_party/renode/stm32l4r5.resc
+++ b/third_party/renode/stm32l4r5.resc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 # SPDX-License-Identifier: MIT
 
 :name: STM32L4R5

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+SPDX-FileCopyrightText: 2022 The IREE bare-metal Arm Authors
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 # Utils

--- a/utils/corstone-300.c
+++ b/utils/corstone-300.c
@@ -1,4 +1,4 @@
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/nrf52840_cmsis.c
+++ b/utils/nrf52840_cmsis.c
@@ -1,4 +1,4 @@
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/nrf5340_cmsis.c
+++ b/utils/nrf5340_cmsis.c
@@ -1,4 +1,4 @@
-// Copyright 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2023 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/stm32f407xx_cmsis.h
+++ b/utils/stm32f407xx_cmsis.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/stm32f411xe_cmsis.h
+++ b/utils/stm32f411xe_cmsis.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/stm32f446xx_cmsis.h
+++ b/utils/stm32f446xx_cmsis.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/stm32f4_cmsis.c
+++ b/utils/stm32f4_cmsis.c
@@ -1,4 +1,4 @@
-// Copyright 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2021 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/stm32f4_libopencm3.c
+++ b/utils/stm32f4_libopencm3.c
@@ -1,4 +1,4 @@
-// Copyright 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2021 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/stm32f7_cmsis.c
+++ b/utils/stm32f7_cmsis.c
@@ -1,4 +1,4 @@
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/stm32l476xx_cmsis.h
+++ b/utils/stm32l476xx_cmsis.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/stm32l4_cmsis.c
+++ b/utils/stm32l4_cmsis.c
@@ -1,4 +1,4 @@
-// Copyright 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2021 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/stm32l4r5xx_cmsis.h
+++ b/utils/stm32l4r5xx_cmsis.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/write.c
+++ b/utils/write.c
@@ -1,4 +1,4 @@
-// Copyright 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2022 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/utils/write_usart.c
+++ b/utils/write_usart.c
@@ -1,4 +1,4 @@
-// Copyright 2021 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+// Copyright 2021 The IREE bare-metal Arm Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
This introduces a seperate AUTHORS file to keep track of contributors and moves the Copyright header format to attribute copyright to "The IREE bare-metal Arm Authors".